### PR TITLE
An implementation addressing issue 7

### DIFF
--- a/src/calmjs/dist.py
+++ b/src/calmjs/dist.py
@@ -171,6 +171,22 @@ def find_packages_requirements_dists(pkg_names, working_set=None):
     return list(reversed(working_set.resolve(requirements)))
 
 
+def find_packages_parents_requirements_dists(pkg_names, working_set=None):
+    """
+    Leverages the `find_packages_requirements_dists` but strip out the
+    distributions that matches pkg_names.
+    """
+
+    dists = []
+    # opting for a naive implementation
+    targets = set(pkg_names)
+    for dist in find_packages_requirements_dists(pkg_names, working_set):
+        if dist.project_name in targets:
+            continue
+        dists.append(dist)
+    return dists
+
+
 def read_dist_egginfo_json(dist, filename=DEFAULT_JSON):
     """
     Safely get a json within an egginfo from a distribution.

--- a/src/calmjs/tests/test_dist.py
+++ b/src/calmjs/tests/test_dist.py
@@ -739,9 +739,21 @@ class DistTestCase(unittest.TestCase):
         # child takes precedences as this was not specified to be merged
         self.assertEqual(results['something_else'], {'child': 'named'})
 
+        results = calmjs_dist.flatten_parents_extras_calmjs(
+            ['app'], working_set=working_set)
+        self.assertEqual(results['node_modules'], {
+            'jquery': 'jquery/dist/jquery.js',
+            'underscore': 'underscore/underscore-min.js',
+        })
+        self.assertEqual(results['something_else'], {'parent': 'lib'})
+
     def test_module_registry_dependencies_failure_no_reg(self):
         self.assertEqual(calmjs_dist.flatten_module_registry_dependencies(
             ['calmjs'], registry_name='calmjs.no_reg',), {})
+
+        self.assertEqual(
+            calmjs_dist.flatten_parents_module_registry_dependencies(
+                ['calmjs'], registry_name='calmjs.no_reg',), {})
 
         self.assertEqual(calmjs_dist.get_module_registry_dependencies(
             ['calmjs'], registry_name='calmjs.no_reg',), {})
@@ -831,6 +843,17 @@ class DistTestCase(unittest.TestCase):
             'forms/ui': '/home/src/forms/ui.js',
         })
 
+        self.assertEqual(
+            calmjs_dist.flatten_parents_module_registry_dependencies(
+                ['site'], registry_name=dummy_regid, working_set=working_set
+            ), {
+                'widget/ui': '/home/src/widget/ui.js',
+                'widget/widget': '/home/src/widget/widget.js',
+                'service/lib': '/home/src/forms/lib.js',
+                'forms/ui': '/home/src/forms/ui.js',
+            }
+        )
+
         service = calmjs_dist.flatten_module_registry_dependencies(
             ['service'], registry_name=dummy_regid, working_set=working_set)
         self.assertEqual(service, {
@@ -855,6 +878,16 @@ class DistTestCase(unittest.TestCase):
             'widget/widget': '/home/src/widget/widget.js',
             'service/lib': '/home/src/forms/lib.js',
         })
+
+        self.assertEqual(
+            calmjs_dist.flatten_parents_module_registry_dependencies(
+                ['forms', 'service', 'app'], registry_name=dummy_regid,
+                working_set=working_set
+            ), {
+                'widget/ui': '/home/src/widget/ui.js',
+                'widget/widget': '/home/src/widget/widget.js',
+            }
+        )
 
         # no declared exports/registry entries in security.
         security = calmjs_dist.flatten_module_registry_dependencies(


### PR DESCRIPTION
Implement the typically needed function that only need the parents.

Skipping `flatten_egginfo_json` as a given package will definitely need its dependencies, not just the parents.

Skipping `flatten_module_registry_names` as it's often useful to get all the registry names regardless, though the parents only version may be useful.  However, the result for this is more trivial in the sense that the output of parents only can be computed by removing all the names returned by `get_module_registry_names`.  Unlike the ones that return the modules, there (usually?) isn't a potential for arbitrarily generated items (as registry names are all explicitly declared on the package).

Fixes #7 