### PR TITLE
Finalize the loaderplugin registry and entry integration

### DIFF
--- a/src/calmjs/README.rst
+++ b/src/calmjs/README.rst
@@ -92,5 +92,14 @@ npm
     done like so for the integrated thing that could inherit from
     anything.
 
+loaderplugin
+    While loader plugin handers of this package can be considered as
+    part of the lower level infrastructure, the actual items being
+    encapsulated is actually JavaScript code that interfaces with the
+    JavaScript/Node.js ecosystem in a rather tightly coupled manner,
+    and that it needs the helpers in the npm module to locate the
+    target source files.  Given that, these objects should only be
+    accessed through the registry system.
+
 As a general rule, a module should not inherit from modules listed below
 their respective position on the above list.

--- a/src/calmjs/base.py
+++ b/src/calmjs/base.py
@@ -720,7 +720,9 @@ class BaseLoaderPluginHandler(object):
         """
 
         stripped_modname = self.strip_plugin(modname)
-        chained = self.registry.get_record(stripped_modname)
+        chained = (
+            self.registry.get_record(stripped_modname)
+            if '!' in stripped_modname else None)
         if chained:
             # ensure the stripped_modname is provided as by default the
             # handler will only deal with its own kind

--- a/src/calmjs/base.py
+++ b/src/calmjs/base.py
@@ -719,7 +719,7 @@ class BaseLoaderPluginHandler(object):
         handler will be used to return this result.
         """
 
-        stripped_modname = self.strip_plugin(modname)
+        stripped_modname = self.unwrap(modname)
         chained = (
             self.registry.get_record(stripped_modname)
             if '!' in stripped_modname else None)
@@ -730,41 +730,47 @@ class BaseLoaderPluginHandler(object):
                 toolchain, spec, stripped_modname, source)
         return stripped_modname
 
-    def locate_bundle_sourcepath(self, toolchain, spec, plugin_sourcepath):
+    def generate_handler_sourcepath(
+            self, toolchain, spec, loaderplugin_sourcepath):
         """
-        The default implementation is a recursive lookup method, which
-        subclasses may make use of.
+        This returns the sourcepath (mapping) that may be added to the
+        appropriate mapping within the spec for a successful toolchain
+        execution.  The value generated is specific to the current
+        spec that is being passed through the toolchain.
+
+        The return value must be a modname: sourcepath mapping, e.g:
+
+        return {
+            'text': '/tmp/src/example_module/text/index.js',
+            'json': '/tmp/src/example_module/json/index.js',
+        }
 
         Subclasses must implement this to return a mapping of modnames
         the the absolute path of the desired sourcefiles.  Example:
 
-        return {
-            'text': '/tmp/src/example_module/text/index.js'
-            'json': '/tmp/src/example_module/json/index.js'
-        }
-
         Implementation must also accept both the toolchain and the spec
-        argument, along with the plugin_sourcepath argument which will
-        be a mapping of {modname: sourcepath} that are relevant to this
-        specific plugin handler.  Instances of subclasses may then
-        derive the the bundle_sourcepath required for a successful build
-        for the given toolchain and spec.
+        argument, along with the loaderplugin_sourcepath argument which
+        will be a mapping of {modname: sourcepath} that are relevant to
+        the current spec being processed through the toolchain.
 
         For nested/chained plugins, the recommended handling method is
-        to also make use of the registry instance assigned to this
-        handler instance to lookup specific handler(s) that may also
-        be registered here, and use their locate_bundle_sourcepath
-        method to generate the mapping required.
+        to make use of the assigned registry instance to lookup relevant
+        loaderplugin handler(s) instances, and make use of their
+        ``generate_handler_sourcepath`` method to generate the mapping
+        required.  The immediate subclass in the loaderplugin module
+        has a generic implementation done in this manner.
         """
 
         return {}
 
-    def strip_plugin(self, value):
+    def unwrap(self, value):
         """
-        Strip the first plugin fragment and return just the value.  This
-        is a simple helper.  Note that the filter chaining can be very
-        implementation specific to each and every loader plugin, so the
-        default implementation is not going to attempt to consume
+        A helper method for unwrapping the loaderplugin fragment out of
+        the provided value (typically a modname) and return it.
+
+        Note that the filter chaining is very implementation specific to
+        each and every loader plugin and their specific toolchain, so
+        this default implementation is not going to attempt to consume
         everything in one go.
         """
 

--- a/src/calmjs/base.py
+++ b/src/calmjs/base.py
@@ -639,3 +639,163 @@ class BaseDriver(object):
         if path:
             return join(cwd, path)
         return cwd
+
+
+class BaseLoaderPluginRegistry(BaseRegistry):
+
+    def _init_entry_point(self, entry_point):
+        try:
+            cls = entry_point.load()
+        except ImportError:
+            logger.warning(
+                "registry '%s' failed to load loader plugin handler for "
+                "entry point '%s'", self.registry_name, entry_point,
+            )
+            return
+
+        if not issubclass(cls, BaseLoaderPluginHandler):
+            logger.warning(
+                "entry point '%s' does not lead to a valid loader plugin "
+                "handler class", entry_point
+            )
+            return
+
+        inst = cls(self, entry_point.name)
+
+        if entry_point.name in self.records:
+            old = type(self.records[entry_point.name])
+            logger.warning(
+                "loader plugin handler for '%s' was already registered to "
+                "an instance of '%s:%s'; '%s' will now override this "
+                "registration",
+                entry_point.name, old.__module__, old.__name__, entry_point
+            )
+        self.records[entry_point.name] = inst
+
+    def to_plugin_name(self, value):
+        """
+        Find the plugin name from the provided value
+        """
+
+        return value.split('!', 1)[0].split('?', 1)[0]
+
+    def get_record(self, name):
+        # it is possible for subclasses to provide a fallback lookup on
+        # "common" registries through the registry framework, e.g.
+        # calmjs.registry.get('some.plugin.reg').get_record(name)
+        return self.records.get(self.to_plugin_name(name))
+
+
+class BaseLoaderPluginHandler(object):
+    """
+    The base loaderplugin handler class provides only the stub methods;
+    for a more concrete implementation, refer to the loaderplugin module
+    for the subclass.
+    """
+
+    def __init__(self, registry, name=None):
+        """
+        The LoaderPluginRegistry will try to construct the instance and
+        pass itself into the constructor; leaving this as the default
+        will enable specific plugins to load further plugins should the
+        input modname has more loader plugin strings.
+        """
+
+        self.registry = registry
+        self.name = name
+
+    def modname_source_to_target(
+            self, toolchain, spec, modname, source):
+        """
+        This is called by the Toolchain for modnames that contain a '!'
+        as that signifies a loaderplugin syntax.  This will be used by
+        the toolchain (which will also be supplied as the first argument)
+        to resolve the copy target, which must be a path relative to the
+        spec[WORKING_DIR].
+
+        If the provided modname points contains a chain of loaders, the
+        registry associated with this handler instance will be used to
+        resolve the subsequent handlers until none are found, which that
+        handler will be used to return this result.
+        """
+
+        stripped_modname = self.strip_plugin(modname)
+        chained = self.registry.get_record(stripped_modname)
+        if chained:
+            # ensure the stripped_modname is provided as by default the
+            # handler will only deal with its own kind
+            return chained.modname_source_to_target(
+                toolchain, spec, stripped_modname, source)
+        return stripped_modname
+
+    def locate_bundle_sourcepath(self, toolchain, spec, plugin_sourcepath):
+        """
+        The default implementation is a recursive lookup method, which
+        subclasses may make use of.
+
+        Subclasses must implement this to return a mapping of modnames
+        the the absolute path of the desired sourcefiles.  Example:
+
+        return {
+            'text': '/tmp/src/example_module/text/index.js'
+            'json': '/tmp/src/example_module/json/index.js'
+        }
+
+        Implementation must also accept both the toolchain and the spec
+        argument, along with the plugin_sourcepath argument which will
+        be a mapping of {modname: sourcepath} that are relevant to this
+        specific plugin handler.  Instances of subclasses may then
+        derive the the bundle_sourcepath required for a successful build
+        for the given toolchain and spec.
+
+        For nested/chained plugins, the recommended handling method is
+        to also make use of the registry instance assigned to this
+        handler instance to lookup specific handler(s) that may also
+        be registered here, and use their locate_bundle_sourcepath
+        method to generate the mapping required.
+        """
+
+        return {}
+
+    def strip_plugin(self, value):
+        """
+        Strip the first plugin fragment and return just the value.  This
+        is a simple helper.  Note that the filter chaining can be very
+        implementation specific to each and every loader plugin, so the
+        default implementation is not going to attempt to consume
+        everything in one go.
+        """
+
+        globs = value.split('!', 1)
+        if globs[0].split('?', 1)[0] == self.name:
+            return globs[-1]
+        else:
+            return value
+
+    def __call__(self, toolchain, spec, modname, source, target, modpath):
+        """
+        These need to provide the actual implementation required for the
+        production of the final artifact, so this will need to locate
+        the resources needed for this set of arguments to function.
+
+        Implementations must return the associated modpaths, targets, and
+        the export_module_name as a 3-tuple, after the copying or
+        transpilation step was done.  Example:
+
+        return (
+            {'text!text_file.txt': 'text!/some/path/text_file.txt'},
+            {'text_file.txt': 'text_file.txt'},
+            ['text!text_file.txt'],
+        )
+
+        Note that implementations can trigger further lookups through
+        the registry instance attached to this instance of the plugin,
+        and implementations must also address the handling of this
+        lookup and usage of the return values.
+
+        Also note that while the toolchain and spec arguments are also
+        provided, they should only be used for lookups; out of band
+        modifications results in convoluted code flow.
+        """
+
+        raise NotImplementedError

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -91,6 +91,30 @@ class BaseLoaderPluginHandler(object):
         self.registry = registry
         self.name = name
 
+    def modname_source_to_target(
+            self, toolchain, spec, modname, source):
+        """
+        This is called by the Toolchain for modnames that contain a '!'
+        as that signifies a loaderplugin syntax.  This will be used by
+        the toolchain (which will also be supplied as the first argument)
+        to resolve the copy target, which must be a path relative to the
+        spec[WORKING_DIR].
+
+        If the provided modname points contains a chain of loaders, the
+        registry associated with this handler instance will be used to
+        resolve the subsequent handlers until none are found, which that
+        handler will be used to return this result.
+        """
+
+        stripped_modname = self.strip_plugin(modname)
+        chained = self.registry.get_record(stripped_modname)
+        if chained:
+            # ensure the stripped_modname is provided as by default the
+            # handler will only deal with its own kind
+            return chained.modname_source_to_target(
+                toolchain, spec, stripped_modname, source)
+        return stripped_modname
+
     def locate_bundle_sourcepath(self, toolchain, spec, plugin_sourcepath):
         """
         The default implementation is a recursive lookup method, which

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -61,8 +61,15 @@ class LoaderPluginRegistry(BaseRegistry):
                 )
             self.records[entry_point.name] = inst
 
+    def to_plugin_name(self, value):
+        """
+        Find the plugin name from the provided value
+        """
+
+        return value.split('!', 1)[0].split('?', 1)[0]
+
     def get_record(self, name):
-        return self.records.get(name)
+        return self.records.get(self.to_plugin_name(name))
 
 
 class BaseLoaderPluginHandler(object):

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -18,7 +18,7 @@ from calmjs.base import BaseLoaderPluginRegistry
 from calmjs.base import BaseLoaderPluginHandler
 from calmjs.toolchain import WORKING_DIR
 from calmjs.toolchain import CALMJS_LOADERPLUGIN_REGISTRY
-from calmjs.toolchain import spec_update_loaderplugin_sourcepath_dict
+from calmjs.toolchain import spec_update_sourcepath_filter_loaderplugins
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ class LoaderPluginHandler(BaseLoaderPluginHandler):
         registry = spec.get(CALMJS_LOADERPLUGIN_REGISTRY)
         if registry:
             fake_spec[CALMJS_LOADERPLUGIN_REGISTRY] = registry
-        spec_update_loaderplugin_sourcepath_dict(fake_spec, {
+        spec_update_sourcepath_filter_loaderplugins(fake_spec, {
             self.unwrap(k): v
             for k, v in loaderplugin_sourcepath.items()
         }, 'current', 'nested')

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -17,7 +17,7 @@ from calmjs.npm import locate_package_entry_file
 from calmjs.base import BaseLoaderPluginRegistry
 from calmjs.base import BaseLoaderPluginHandler
 from calmjs.toolchain import WORKING_DIR
-from calmjs.toolchain import spec_update_loaderplugins_sourcepath_dict
+from calmjs.toolchain import spec_update_loaderplugin_sourcepath_dict
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class LoaderPluginHandler(BaseLoaderPluginHandler):
         # making use of the filtering helper function for grouping
         # the inner mappings
         fake_spec = {}
-        spec_update_loaderplugins_sourcepath_dict(fake_spec, {
+        spec_update_loaderplugin_sourcepath_dict(fake_spec, {
             self.strip_plugin(k): v
             for k, v in plugin_sourcepath.items()
         }, 'current', 'nested')

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -14,103 +14,32 @@ from os.path import exists
 from os.path import join
 
 from calmjs.npm import locate_package_entry_file
-from calmjs.base import BaseRegistry
+from calmjs.base import BaseLoaderPluginRegistry
+from calmjs.base import BaseLoaderPluginHandler
 from calmjs.toolchain import WORKING_DIR
 from calmjs.toolchain import spec_update_loaderplugins_sourcepath_dict
 
 logger = logging.getLogger(__name__)
 
 
-class LoaderPluginRegistry(BaseRegistry):
+class LoaderPluginRegistry(BaseLoaderPluginRegistry):
+    """
+    Standard loaderplugin registry - with the default _init method
+    calling the _init_entry_point method for setting up the raw
+    entry points captured from the working set.
+    """
 
     def _init(self, *a, **kw):
         self._init_entry_points(self.raw_entry_points)
 
-    def _init_entry_point(self, entry_point):
-        try:
-            cls = entry_point.load()
-        except ImportError:
-            logger.warning(
-                "registry '%s' failed to load loader plugin handler for "
-                "entry point '%s'", self.registry_name, entry_point,
-            )
-            return
 
-        if not issubclass(cls, BaseLoaderPluginHandler):
-            logger.warning(
-                "entry point '%s' does not lead to a valid loader plugin "
-                "handler class", entry_point
-            )
-            return
-
-        inst = cls(self, entry_point.name)
-
-        if entry_point.name in self.records:
-            old = type(self.records[entry_point.name])
-            logger.warning(
-                "loader plugin handler for '%s' was already registered to "
-                "an instance of '%s:%s'; '%s' will now override this "
-                "registration",
-                entry_point.name, old.__module__, old.__name__, entry_point
-            )
-        self.records[entry_point.name] = inst
-
-    def to_plugin_name(self, value):
-        """
-        Find the plugin name from the provided value
-        """
-
-        return value.split('!', 1)[0].split('?', 1)[0]
-
-    def get_record(self, name):
-        # it is possible for subclasses to provide a fallback lookup on
-        # "common" registries through the registry framework, e.g.
-        # calmjs.registry.get('some.plugin.reg').get_record(name)
-        return self.records.get(self.to_plugin_name(name))
-
-
-class BaseLoaderPluginHandler(object):
+class LoaderPluginHandler(BaseLoaderPluginHandler):
     """
     Generic loader plugin handler encapsulates the specific handling
     rules for a successful build; this includes dealing with injection
     of specific bundle sourcepaths and the like for the target framework
     to be supported by subclasses.
     """
-
-    def __init__(self, registry, name=None):
-        """
-        The LoaderPluginRegistry will try to construct the instance and
-        pass itself into the constructor; leaving this as the default
-        will enable specific plugins to load further plugins should the
-        input modname has more loader plugin strings.
-        """
-
-        self.registry = registry
-        self.name = name
-
-    def modname_source_to_target(
-            self, toolchain, spec, modname, source):
-        """
-        This is called by the Toolchain for modnames that contain a '!'
-        as that signifies a loaderplugin syntax.  This will be used by
-        the toolchain (which will also be supplied as the first argument)
-        to resolve the copy target, which must be a path relative to the
-        spec[WORKING_DIR].
-
-        If the provided modname points contains a chain of loaders, the
-        registry associated with this handler instance will be used to
-        resolve the subsequent handlers until none are found, which that
-        handler will be used to return this result.
-        """
-
-        stripped_modname = self.strip_plugin(modname)
-        chained = self.registry.get_record(stripped_modname)
-        if chained:
-            # ensure the stripped_modname is provided as by default the
-            # handler will only deal with its own kind
-            return chained.modname_source_to_target(
-                toolchain, spec, stripped_modname, source)
-        return stripped_modname
 
     def locate_bundle_sourcepath(self, toolchain, spec, plugin_sourcepath):
         """
@@ -172,51 +101,8 @@ class BaseLoaderPluginHandler(object):
                 toolchain, spec, sourcepath))
         return result
 
-    def strip_plugin(self, value):
-        """
-        Strip the first plugin fragment and return just the value.  This
-        is a simple helper.  Note that the filter chaining can be very
-        implementation specific to each and every loader plugin, so the
-        default implementation is not going to attempt to consume
-        everything in one go.
-        """
 
-        globs = value.split('!', 1)
-        if globs[0].split('?', 1)[0] == self.name:
-            return globs[-1]
-        else:
-            return value
-
-    def __call__(self, toolchain, spec, modname, source, target, modpath):
-        """
-        These need to provide the actual implementation required for the
-        production of the final artifact, so this will need to locate
-        the resources needed for this set of arguments to function.
-
-        Implementations must return the associated modpaths, targets, and
-        the export_module_name as a 3-tuple, after the copying or
-        transpilation step was done.  Example:
-
-        return (
-            {'text!text_file.txt': 'text!/some/path/text_file.txt'},
-            {'text_file.txt': 'text_file.txt'},
-            ['text!text_file.txt'],
-        )
-
-        Note that implementations can trigger further lookups through
-        the registry instance attached to this instance of the plugin,
-        and implementations must also address the handling of this
-        lookup and usage of the return values.
-
-        Also note that while the toolchain and spec arguments are also
-        provided, they should only be used for lookups; out of band
-        modifications results in convoluted code flow.
-        """
-
-        raise NotImplementedError
-
-
-class NPMLoaderPluginHandler(BaseLoaderPluginHandler):
+class NPMLoaderPluginHandler(LoaderPluginHandler):
     """
     Encapsulates a loader plugin sourced from NPM (i.e. node_modules);
     this provides a framework to deal with path mangling and/or

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -179,14 +179,24 @@ class NPMLoaderPluginHandler(BaseLoaderPluginHandler):
         if not self.node_module_pkg_name:
             return {}
 
+        working_dir = spec.get(WORKING_DIR, None)
+        if working_dir is None:
+            logger.info(
+                "attempting to derive working directory using %s, as the "
+                "provided spec is missing working_dir", toolchain
+            )
+            working_dir = toolchain.join_cwd()
+
+        logger.debug("deriving npm loader plugin from '%s'", working_dir)
+
         target = locate_package_entry_file(
-            spec[WORKING_DIR], self.node_module_pkg_name)
+            working_dir, self.node_module_pkg_name)
         if target:
             logger.debug('picked %r for loader plugin %r', target, self.name)
             return {self.name: target}
 
         if exists(join(
-                spec[WORKING_DIR], 'node_modules', self.node_module_pkg_name,
+                working_dir, 'node_modules', self.node_module_pkg_name,
                 'package.json')):
             logger.warning(
                 "'package.json' for the npm package '%s' does not contain a "
@@ -203,7 +213,7 @@ class NPMLoaderPluginHandler(BaseLoaderPluginHandler):
                 "as a workaround, though the package that owns that source "
                 "file that has this requirement should declare an explicit "
                 "dependency; the build process may fail",
-                self.node_module_pkg_name, self.name, spec[WORKING_DIR],
+                self.node_module_pkg_name, self.name, working_dir,
                 self.node_module_pkg_name,
             )
 

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -122,6 +122,13 @@ class BaseLoaderPluginHandler(object):
         }, 'current', 'nested')
         result = {}
         for plugin_name, sourcepath in fake_spec['nested'].items():
+            if sourcepath == plugin_sourcepath:
+                logger.warning(
+                    "loaderplugin '%s' extracted same sourcepath of while "
+                    "locating chain loaders: %s; skipping",
+                    self.name, sourcepath
+                )
+                continue
             plugin = self.registry.get_record(plugin_name)
             if not plugin:
                 logger.warning(
@@ -146,9 +153,9 @@ class BaseLoaderPluginHandler(object):
         everything in one go.
         """
 
-        if value.startswith(self.name + '!'):
-            result = value.split('!', 1)
-            return result[-1]
+        globs = value.split('!', 1)
+        if globs[0].split('?', 1)[0] == self.name:
+            return globs[-1]
         else:
             return value
 

--- a/src/calmjs/loaderplugin.py
+++ b/src/calmjs/loaderplugin.py
@@ -17,6 +17,7 @@ from calmjs.npm import locate_package_entry_file
 from calmjs.base import BaseLoaderPluginRegistry
 from calmjs.base import BaseLoaderPluginHandler
 from calmjs.toolchain import WORKING_DIR
+from calmjs.toolchain import CALMJS_LOADERPLUGIN_REGISTRY
 from calmjs.toolchain import spec_update_loaderplugin_sourcepath_dict
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,9 @@ class LoaderPluginHandler(BaseLoaderPluginHandler):
         # making use of the filtering helper function for grouping
         # the inner mappings
         fake_spec = {}
+        registry = spec.get(CALMJS_LOADERPLUGIN_REGISTRY)
+        if registry:
+            fake_spec[CALMJS_LOADERPLUGIN_REGISTRY] = registry
         spec_update_loaderplugin_sourcepath_dict(fake_spec, {
             self.strip_plugin(k): v
             for k, v in plugin_sourcepath.items()

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -669,6 +669,7 @@ class ToolchainRuntime(DriverRuntime):
 
         argparser.add_argument(
             '--export-target', dest=EXPORT_TARGET,
+            metavar=EXPORT_TARGET,
             default=default,
             help=help,
         )
@@ -694,6 +695,7 @@ class ToolchainRuntime(DriverRuntime):
         cwd = self.toolchain.join_cwd()
         argparser.add_argument(
             '--working-dir', dest=WORKING_DIR,
+            metavar=WORKING_DIR,
             default=cwd,
             help=help_template % {'explanation': explanation, 'cwd': cwd},
         )
@@ -713,7 +715,9 @@ class ToolchainRuntime(DriverRuntime):
         """
 
         argparser.add_argument(
-            '--build-dir', default=None, dest=BUILD_DIR, help=help)
+            '--build-dir', default=None, dest=BUILD_DIR,
+            metavar=BUILD_DIR, help=help,
+        )
 
     def init_argparser_optional_advice(
             self, argparser, default=[], help=(
@@ -730,6 +734,7 @@ class ToolchainRuntime(DriverRuntime):
         argparser.add_argument(
             '--optional-advice', default=default, required=False,
             dest=ADVICE_PACKAGES, action=StoreRequirementList,
+            metavar='advice[,advice[...]]',
             help=help
         )
 
@@ -858,6 +863,7 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
         argparser.add_argument(
             '--source-registry', default=default,
             dest=CALMJS_MODULE_REGISTRY_NAMES, action=StoreDelimitedList,
+            metavar='registry_name[,registry_name[...]]',
             help=help,
         )
 
@@ -885,6 +891,7 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
         argparser.add_argument(
             '--loaderplugin-registry', default=default,
             dest=CALMJS_LOADERPLUGIN_REGISTRY_NAMES, action=StoreDelimitedList,
+            metavar='registry_name[,registry_name[...]]',
             help=help,
         )
 
@@ -902,7 +909,7 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
 
         argparser.add_argument(
             SOURCE_PACKAGE_NAMES, help=help,
-            metavar='package_names', nargs='+',
+            metavar='package_name', nargs='+',
         )
 
     def init_argparser(self, argparser):
@@ -1041,7 +1048,7 @@ class PackageManagerRuntime(DriverRuntime):
 
         argparser.add_argument(
             'package_names', help='names of the python package to use',
-            metavar='package_names', nargs='+',
+            metavar='package_name', nargs='+',
         )
 
     def run(self, argpaser=None, interactive=False, **kwargs):

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -31,7 +31,7 @@ from calmjs.toolchain import ADVICE_PACKAGES
 from calmjs.toolchain import AFTER_PREPARE
 from calmjs.toolchain import BUILD_DIR
 from calmjs.toolchain import CALMJS_MODULE_REGISTRY_NAMES
-from calmjs.toolchain import CALMJS_LOADERPLUGIN_REGISTRY_NAMES
+from calmjs.toolchain import CALMJS_LOADERPLUGIN_REGISTRY_NAME
 from calmjs.toolchain import CALMJS_TOOLCHAIN_ADVICE
 from calmjs.toolchain import DEBUG
 from calmjs.toolchain import EXPORT_TARGET
@@ -875,9 +875,8 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
 
     def init_argparser_loaderplugin_registry(
             self, argparser, default=None, help=(
-                'comma separated list of registries to use for the handling '
-                'of loader plugins that may be loaded from the given Python '
-                'packages'
+                'the name of the registry to use for the handling of loader '
+                'plugins that may be loaded from the given Python packages'
             )):
         """
         Default helper for setting up the loaderplugin registries flags.
@@ -890,15 +889,9 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
 
         argparser.add_argument(
             '--loaderplugin-registry', default=default,
-            dest=CALMJS_LOADERPLUGIN_REGISTRY_NAMES, action=StoreDelimitedList,
-            metavar='registry_name[,registry_name[...]]',
+            dest=CALMJS_LOADERPLUGIN_REGISTRY_NAME, action='store',
+            metavar='registry_name',
             help=help,
-        )
-
-        argparser.add_argument(
-            '--loaderplugin-registries', default=default,
-            dest=CALMJS_LOADERPLUGIN_REGISTRY_NAMES, action=StoreDelimitedList,
-            help=SUPPRESS,
         )
 
     def init_argparser_package_names(

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -855,13 +855,13 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
         """
 
         argparser.add_argument(
-            '--source-registry', default=None,
+            '--source-registry', default=default,
             dest=CALMJS_MODULE_REGISTRY_NAMES, action=StoreDelimitedList,
             help=help,
         )
 
         argparser.add_argument(
-            '--source-registries', default=None,
+            '--source-registries', default=default,
             dest=CALMJS_MODULE_REGISTRY_NAMES, action=StoreDelimitedList,
             help=SUPPRESS,
         )

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -31,6 +31,7 @@ from calmjs.toolchain import ADVICE_PACKAGES
 from calmjs.toolchain import AFTER_PREPARE
 from calmjs.toolchain import BUILD_DIR
 from calmjs.toolchain import CALMJS_MODULE_REGISTRY_NAMES
+from calmjs.toolchain import CALMJS_LOADERPLUGIN_REGISTRY_NAMES
 from calmjs.toolchain import CALMJS_TOOLCHAIN_ADVICE
 from calmjs.toolchain import DEBUG
 from calmjs.toolchain import EXPORT_TARGET
@@ -863,6 +864,33 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
         argparser.add_argument(
             '--source-registries', default=default,
             dest=CALMJS_MODULE_REGISTRY_NAMES, action=StoreDelimitedList,
+            help=SUPPRESS,
+        )
+
+    def init_argparser_loaderplugin_registry(
+            self, argparser, default=None, help=(
+                'comma separated list of registries to use for the handling '
+                'of loader plugins that may be loaded from the given Python '
+                'packages'
+            )):
+        """
+        Default helper for setting up the loaderplugin registries flags.
+
+        Note that this is NOT part of the init_argparser due to
+        implementation specific requirements.  Subclasses should
+        consider modifying the default value help message to cater to the
+        toolchain it encapsulates.
+        """
+
+        argparser.add_argument(
+            '--loaderplugin-registry', default=default,
+            dest=CALMJS_LOADERPLUGIN_REGISTRY_NAMES, action=StoreDelimitedList,
+            help=help,
+        )
+
+        argparser.add_argument(
+            '--loaderplugin-registries', default=default,
+            dest=CALMJS_LOADERPLUGIN_REGISTRY_NAMES, action=StoreDelimitedList,
             help=SUPPRESS,
         )
 

--- a/src/calmjs/tests/test_base.py
+++ b/src/calmjs/tests/test_base.py
@@ -61,12 +61,23 @@ class BasePkgRefRegistryTestCase(unittest.TestCase):
         registry = base.BasePkgRefRegistry(__name__, _working_set=working_set)
         self.assertEqual(list(registry.iter_records()), [])
 
-    def test_not_implemented(self):
-        working_set = mocks.WorkingSet({__name__: [
+    def test_no_op_default(self):
+        working_set = mocks.WorkingSet({'regname': [
             'calmjs.testing.module1 = calmjs.testing.module1',
-        ]})
-        with self.assertRaises(NotImplementedError):
-            base.BasePkgRefRegistry(__name__, _working_set=working_set)
+        ]}, dist=Distribution(project_name='some.project', version='1.0'))
+        with pretty_logging(stream=mocks.StringIO()) as s:
+            base.BasePkgRefRegistry('regname', _working_set=working_set)
+        self.assertIn(
+            "registering 1 entry points for registry 'regname'", s.getvalue())
+        self.assertIn(
+            "registering entry point 'calmjs.testing.module1 = "
+            "calmjs.testing.module1' from 'some.project 1.0'", s.getvalue())
+        self.assertIn(
+            "registration of entry point 'calmjs.testing.module1 = "
+            "calmjs.testing.module1' from 'some.project 1.0' to registry "
+            "'regname' failed",
+            s.getvalue())
+        self.assertIn('NotImplemented', s.getvalue())
 
 
 class BaseModuleRegistryTestCase(unittest.TestCase):
@@ -95,12 +106,13 @@ class BaseModuleRegistryTestCase(unittest.TestCase):
         self.assertEqual(registry.get_record('module'), {})
         self.assertEqual(list(registry.iter_records()), [])
 
-    def test_not_implemented(self):
+    def test_no_op_default(self):
         working_set = mocks.WorkingSet({__name__: [
             'calmjs.testing.module1 = calmjs.testing.module1',
         ]})
-        with self.assertRaises(NotImplementedError):
+        with pretty_logging(stream=mocks.StringIO()) as s:
             base.BaseModuleRegistry(__name__, _working_set=working_set)
+        self.assertIn('NotImplemented', s.getvalue())
 
     def test_dummy_implemented(self):
         from calmjs.testing import module1

--- a/src/calmjs/tests/test_loaderplugin.py
+++ b/src/calmjs/tests/test_loaderplugin.py
@@ -36,6 +36,14 @@ class DupePlugin(BaseLoaderPluginHandler):
 
 class LoaderPluginRegistryTestCase(unittest.TestCase):
 
+    def test_to_plugin_name(self):
+        registry = LoaderPluginRegistry(
+            'calmjs.loader_plugin', _working_set=WorkingSet({}))
+        self.assertEqual('example', registry.to_plugin_name('example'))
+        self.assertEqual('example', registry.to_plugin_name('example?hi'))
+        self.assertEqual('example', registry.to_plugin_name('example!hi'))
+        self.assertEqual('example', registry.to_plugin_name('example?arg!hi'))
+
     def test_initialize_standard(self):
         # ensure that we have a proper working registry
         working_set = WorkingSet({'calmjs.loader_plugin': [
@@ -111,6 +119,13 @@ class LoaderPluginRegistryTestCase(unittest.TestCase):
         # the second one will be registered
         self.assertTrue(
             isinstance(registry.get('example'), BaseLoaderPluginHandler))
+        # ensure that the handler can be acquired from a full name
+        self.assertEqual('example', registry.get('example!hi').name)
+        self.assertEqual('example', registry.get('example?arg!hi').name)
+        self.assertEqual('example', registry.get('example?arg').name)
+        self.assertIsNone(registry.get('examplearg'))
+        self.assertIsNone(registry.get('ex'))
+        self.assertIsNone(registry.get('ex!ample'))
 
 
 class BaseLoaderPluginHandlerTestcase(unittest.TestCase):

--- a/src/calmjs/tests/test_loaderplugin.py
+++ b/src/calmjs/tests/test_loaderplugin.py
@@ -172,6 +172,32 @@ class LoaderPluginHandlerTestcase(unittest.TestCase):
                 'base!bad': 'base!bad',
             }), {})
 
+    def test_plugin_locate_bundle_sourcepath_default_registry(self):
+        base = LoaderPluginHandler(None, 'base')
+        toolchain = NullToolchain()
+        spec = Spec(working_dir=mkdtemp(self))
+        with pretty_logging(stream=StringIO()) as stream:
+            self.assertEqual(
+                base.locate_bundle_sourcepath(toolchain, spec, {
+                    'base!bad': 'base!bad',
+                }), {})
+        self.assertIn("using default loaderplugin registry", stream.getvalue())
+
+    def test_plugin_locate_bundle_sourcepath_resolved_registry(self):
+        base = LoaderPluginHandler(None, 'base')
+        reg = LoaderPluginRegistry('loaders', _working_set=WorkingSet({}))
+        toolchain = NullToolchain()
+        spec = Spec(
+            working_dir=mkdtemp(self), calmjs_loaderplugin_registry=reg)
+        with pretty_logging(stream=StringIO()) as stream:
+            self.assertEqual(
+                base.locate_bundle_sourcepath(toolchain, spec, {
+                    'base!bad': 'base!bad',
+                }), {})
+        self.assertIn(
+            "loaderplugin registry 'loaders' already assigned to spec",
+            stream.getvalue())
+
     def test_plugin_package_strip_broken_recursion_stop(self):
         class BadPluginHandler(LoaderPluginHandler):
             def strip_plugin(self, value):

--- a/src/calmjs/tests/test_loaderplugin.py
+++ b/src/calmjs/tests/test_loaderplugin.py
@@ -4,6 +4,7 @@ import unittest
 from os.path import join
 from os import chdir
 from os import makedirs
+from pkg_resources import Distribution
 
 from calmjs.loaderplugin import LoaderPluginRegistry
 from calmjs.loaderplugin import BaseLoaderPluginHandler
@@ -88,16 +89,16 @@ class LoaderPluginRegistryTestCase(unittest.TestCase):
     def test_initialize_failure_bad_plugin(self):
         working_set = WorkingSet({'calmjs.loader_plugin': [
             'bad_plugin = calmjs.tests.test_loaderplugin:BadPlugin',
-        ]})
+        ]}, dist=Distribution(project_name='plugin', version='1.0'))
         # should not trigger import failure
         with pretty_logging(stream=StringIO()) as stream:
             registry = LoaderPluginRegistry(
                 'calmjs.loader_plugin', _working_set=working_set)
         self.assertIsNone(registry.get('bad_plugin'))
         self.assertIn(
-            "the loader plugin class registered at 'bad_plugin = "
-            "calmjs.tests.test_loaderplugin:BadPlugin' failed "
-            "to be instantiated with the following exception",
+            "registration of entry point "
+            "'bad_plugin = calmjs.tests.test_loaderplugin:BadPlugin' from "
+            "'plugin 1.0' to registry 'calmjs.loader_plugin' failed",
             stream.getvalue()
         )
 

--- a/src/calmjs/tests/test_loaderplugin.py
+++ b/src/calmjs/tests/test_loaderplugin.py
@@ -43,8 +43,8 @@ class LoaderPluginRegistryTestCase(unittest.TestCase):
             'calmjs.loader_plugin', _working_set=working_set)
         plugin = registry.get('example')
         self.assertTrue(isinstance(plugin, BaseLoaderPluginHandler))
-        with self.assertRaises(NotImplementedError):
-            plugin.locate_plugin_source(NullToolchain(), Spec())
+        self.assertEqual(
+            {}, plugin.locate_bundle_sourcepath(NullToolchain(), Spec(), {}))
 
     def test_initialize_failure_missing(self):
         working_set = WorkingSet({'calmjs.loader_plugin': [
@@ -143,7 +143,8 @@ class NPMPluginTestCase(unittest.TestCase):
         base = NPMLoaderPluginHandler(None, 'base')
         toolchain = NullToolchain()
         spec = Spec(working_dir=mkdtemp(self))
-        self.assertEqual(base.locate_plugin_source(toolchain, spec), {})
+        self.assertEqual(
+            base.locate_bundle_sourcepath(toolchain, spec, {}), {})
 
     def test_plugin_package_missing_dir(self):
         base = NPMLoaderPluginHandler(None, 'base')
@@ -151,7 +152,8 @@ class NPMPluginTestCase(unittest.TestCase):
         toolchain = NullToolchain()
         spec = Spec(working_dir=mkdtemp(self))
         with pretty_logging(stream=StringIO()) as stream:
-            self.assertEqual(base.locate_plugin_source(toolchain, spec), {})
+            self.assertEqual(
+                base.locate_bundle_sourcepath(toolchain, spec, {}), {})
         self.assertIn(
             "could not locate 'package.json' for the npm package 'dummy_pkg' "
             "which was specified to contain the loader plugin 'base' in the "
@@ -170,7 +172,8 @@ class NPMPluginTestCase(unittest.TestCase):
             fd.write('{}')
 
         with pretty_logging(stream=StringIO()) as stream:
-            self.assertEqual(base.locate_plugin_source(toolchain, spec), {})
+            self.assertEqual(
+                base.locate_bundle_sourcepath(toolchain, spec, {}), {})
 
         self.assertIn(
             "calmjs.loaderplugin 'package.json' for the npm package "
@@ -193,7 +196,7 @@ class NPMPluginTestCase(unittest.TestCase):
         with pretty_logging(stream=StringIO()) as stream:
             self.assertEqual(
                 join(pkg_dir, 'base.js'),
-                base.locate_plugin_source(toolchain, spec)['base'],
+                base.locate_bundle_sourcepath(toolchain, spec, {})['base'],
             )
         self.assertIn("for loader plugin 'base'", stream.getvalue())
 
@@ -210,6 +213,6 @@ class NPMPluginTestCase(unittest.TestCase):
         with pretty_logging(stream=StringIO()) as stream:
             self.assertEqual(
                 join(pkg_dir, 'browser', 'base.js'),
-                base.locate_plugin_source(toolchain, spec)['base'],
+                base.locate_bundle_sourcepath(toolchain, spec, {})['base'],
             )
         self.assertIn("for loader plugin 'base'", stream.getvalue())

--- a/src/calmjs/tests/test_loaderplugin.py
+++ b/src/calmjs/tests/test_loaderplugin.py
@@ -221,6 +221,21 @@ class LoaderPluginHandlerTestcase(unittest.TestCase):
             toolchain, spec, 'base!intercept!base!fun.file',
             '/some/path/fun.file'))
 
+    def test_plugin_loaders_modname_source_to_target_identity(self):
+        # manually create a registry
+        reg = LoaderPluginRegistry('simloaders', _working_set=WorkingSet({}))
+        base = reg.records['local/dev'] = LoaderPluginHandler(reg, 'local/dev')
+        toolchain = NullToolchain()
+        spec = Spec()
+
+        self.assertEqual('fun.file', base.modname_source_to_target(
+            toolchain, spec, 'local/dev!fun.file',
+            '/some/path/fun.file'))
+        # a redundant usage test
+        self.assertEqual('local/dev', base.modname_source_to_target(
+            toolchain, spec, 'local/dev',
+            '/some/path/to/the/plugin'))
+
 
 class NPMPluginTestCase(unittest.TestCase):
 

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -748,7 +748,7 @@ class RuntimeLoaderPluginRegistryOptionTestCase(unittest.TestCase):
         known, extras = parser.parse_known_args(
             ['--loaderplugin-registry', 'reg1,reg2', 'example.package'])
         self.assertEqual(
-            known.calmjs_loaderplugin_registry_names, ['reg1', 'reg2'])
+            known.calmjs_loaderplugin_registry_name, 'reg1,reg2')
         self.assertEqual(
             known.source_package_names, ['example.package'])
 

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -692,6 +692,32 @@ class SourcePackageToolchainRuntimeTestCase(unittest.TestCase):
         self.assertEqual(
             known.source_package_names, ['example.package'])
 
+    def test_source_package_toolchain_default(self):
+        stub_stdouts(self)
+        parser = ArgumentParser()
+        tc = toolchain.NullToolchain()
+        rt = runtime.SourcePackageToolchainRuntime(tc)
+        rt.init_argparser(parser)
+        known, extras = parser.parse_known_args(['example.package'])
+        self.assertEqual(known.calmjs_module_registry_names, None)
+
+    def test_source_package_toolchain_argparser_default_registry(self):
+        class CustomRuntime(runtime.SourcePackageToolchainRuntime):
+            def init_argparser_source_registry(self, argparser):
+                super(CustomRuntime, self).init_argparser_source_registry(
+                    argparser, default=('default_reg',))
+
+        stub_stdouts(self)
+        parser = ArgumentParser()
+        tc = toolchain.NullToolchain()
+        rt = CustomRuntime(tc)
+        rt.init_argparser(parser)
+        known, extras = parser.parse_known_args(['example.package'])
+        self.assertEqual(
+            known.calmjs_module_registry_names, ('default_reg',))
+        self.assertEqual(
+            known.source_package_names, ['example.package'])
+
 
 class PackageManagerDriverTestCase(unittest.TestCase):
     """

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -676,6 +676,7 @@ class SourcePackageToolchainRuntimeTestCase(unittest.TestCase):
         tc = toolchain.NullToolchain()
         rt = runtime.SourcePackageToolchainRuntime(tc)
         text = rt.argparser.format_help()
+        self.assertNotIn("--loaderplugin-registry", text)
         self.assertIn("--source-registry", text)
         self.assertTrue(isinstance(rt.create_spec(), toolchain.Spec))
 
@@ -715,6 +716,39 @@ class SourcePackageToolchainRuntimeTestCase(unittest.TestCase):
         known, extras = parser.parse_known_args(['example.package'])
         self.assertEqual(
             known.calmjs_module_registry_names, ('default_reg',))
+        self.assertEqual(
+            known.source_package_names, ['example.package'])
+
+
+class LoaderPluginToolchainRuntime(runtime.SourcePackageToolchainRuntime):
+
+    def init_argparser(self, argparser):
+        super(LoaderPluginToolchainRuntime, self).init_argparser(argparser)
+        self.init_argparser_loaderplugin_registry(argparser)
+
+
+class RuntimeLoaderPluginRegistryOptionTestCase(unittest.TestCase):
+    """
+    Test out the --loaderplugin-registry flag.
+    """
+
+    def test_loaderplugin_toolchain_basic(self):
+        tc = toolchain.NullToolchain()
+        rt = LoaderPluginToolchainRuntime(tc)
+        text = rt.argparser.format_help()
+        self.assertIn("--loaderplugin-registry", text)
+        self.assertTrue(isinstance(rt.create_spec(), toolchain.Spec))
+
+    def test_loaderplugin_toolchain_argparser(self):
+        stub_stdouts(self)
+        parser = ArgumentParser()
+        tc = toolchain.NullToolchain()
+        rt = LoaderPluginToolchainRuntime(tc)
+        rt.init_argparser(parser)
+        known, extras = parser.parse_known_args(
+            ['--loaderplugin-registry', 'reg1,reg2', 'example.package'])
+        self.assertEqual(
+            known.calmjs_loaderplugin_registry_names, ['reg1', 'reg2'])
         self.assertEqual(
             known.source_package_names, ['example.package'])
 

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -1142,6 +1142,7 @@ class ToolchainLoaderPluginTestCase(unittest.TestCase):
         src = join(src_dir, 'target.txt')
         spec = Spec()
         with pretty_logging(stream=StringIO()) as s:
+            self.toolchain.prepare_loaderplugin_registries(spec)
             results = self.toolchain.compile_loaderplugin_entry(spec, (
                 'foo!target.txt', src, 'foo!target.txt', 'foo!target.txt'))
         self.assertIn(
@@ -1175,6 +1176,7 @@ class ToolchainLoaderPluginTestCase(unittest.TestCase):
             calmjs_loaderplugin_registry_names=['calmjs.loaderplugins_1'],
         )
         with pretty_logging(stream=StringIO()) as s:
+            self.toolchain.prepare_loaderplugin_registries(spec)
             self.toolchain.compile_loaderplugin_entry(spec, (
                 'bar!target.txt', src, 'bar!target.txt', 'bar!target.txt'))
             foo_results = self.toolchain.compile_loaderplugin_entry(spec, (
@@ -1201,6 +1203,7 @@ class ToolchainLoaderPluginTestCase(unittest.TestCase):
             ],
         )
         with pretty_logging(stream=StringIO()) as s:
+            self.toolchain.prepare_loaderplugin_registries(spec)
             bar_results = self.toolchain.compile_loaderplugin_entry(spec, (
                 'bar!target.txt', src, 'bar!target.txt', 'bar!target.txt'))
             self.toolchain.compile_loaderplugin_entry(spec, (

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -34,7 +34,8 @@ from calmjs.toolchain import Toolchain
 from calmjs.toolchain import NullToolchain
 from calmjs.toolchain import ES5Toolchain
 from calmjs.toolchain import ToolchainSpecCompileEntry
-from calmjs.toolchain import dict_get
+from calmjs.toolchain import dict_setget
+from calmjs.toolchain import dict_setget_dict
 from calmjs.toolchain import dict_update_overwrite_check
 from calmjs.toolchain import spec_update_plugins_sourcepath_dict
 from calmjs.toolchain import toolchain_spec_entries_compile
@@ -79,18 +80,27 @@ def dummy(spec, extras):
         spec['extras'] = extras
 
 
-class DictGetTestCase(unittest.TestCase):
+class DictSetGetTestCase(unittest.TestCase):
     """
     A special get that also creates keys.
     """
 
-    def test_dict_get(self):
+    def test_dict_setget(self):
         items = {}
-        dict_get(items, 'a_key')
+        value = []
+        dict_setget(items, 'a_key', value)
+        self.assertIs(value, items['a_key'])
+        other = []
+        dict_setget(items, 'a_key', other)
+        self.assertIsNot(other, items['a_key'])
+
+    def test_dict_setget_dict(self):
+        items = {}
+        dict_setget_dict(items, 'a_key')
         self.assertEqual(items, {'a_key': {}})
 
         a_key = items['a_key']
-        dict_get(items, 'a_key')
+        dict_setget_dict(items, 'a_key')
         self.assertIs(items['a_key'], a_key)
 
 

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -38,7 +38,7 @@ from calmjs.toolchain import ToolchainSpecCompileEntry
 from calmjs.toolchain import dict_setget
 from calmjs.toolchain import dict_setget_dict
 from calmjs.toolchain import dict_update_overwrite_check
-from calmjs.toolchain import spec_update_loaderplugins_sourcepath_dict
+from calmjs.toolchain import spec_update_loaderplugin_sourcepath_dict
 from calmjs.toolchain import spec_update_loaderplugin_registry
 from calmjs.toolchain import toolchain_spec_entries_compile
 
@@ -211,7 +211,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
             'standard.module': 'standard.module',
         }
         spec = {}
-        spec_update_loaderplugins_sourcepath_dict(
+        spec_update_loaderplugin_sourcepath_dict(
             spec, sourcepath_dict, 'sourcepath_key', 'plugins_key')
         self.assertTrue(isinstance(spec.pop(
             'calmjs_loaderplugin_registry'), BaseLoaderPluginRegistry))
@@ -230,7 +230,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
         base_map = {}
         spec = {'sourcepath_key': base_map}
 
-        spec_update_loaderplugins_sourcepath_dict(
+        spec_update_loaderplugin_sourcepath_dict(
             spec, sourcepath_dict, 'sourcepath_key', 'plugins_key')
         self.assertTrue(isinstance(spec.pop(
             'calmjs_loaderplugin_registry'), BaseLoaderPluginRegistry))
@@ -249,7 +249,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
         }
         spec = {}
 
-        spec_update_loaderplugins_sourcepath_dict(
+        spec_update_loaderplugin_sourcepath_dict(
             spec, sourcepath_dict, 'sourcepath_key', 'plugins_key')
         self.assertTrue(isinstance(spec.pop(
             'calmjs_loaderplugin_registry'), BaseLoaderPluginRegistry))
@@ -272,7 +272,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
         })
 
         # subsequent update will do update, not overwrite.
-        spec_update_loaderplugins_sourcepath_dict(spec, {
+        spec_update_loaderplugin_sourcepath_dict(spec, {
             'text!argument2': 'some/text/file2.txt',
         }, 'sourcepath_key', 'plugins_key')
 

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -151,6 +151,14 @@ class SpecResolveRegistryTestCase(unittest.TestCase):
         self.assertTrue(isinstance(registry, BaseLoaderPluginRegistry))
         self.assertIn('no loaderplugin registry found in spec', s.getvalue())
 
+    def test_default(self):
+        spec = {}
+        default = BaseLoaderPluginRegistry('some.registry')
+        with pretty_logging(stream=StringIO()) as s:
+            registry = spec_update_loaderplugin_registry(spec, default=default)
+        self.assertIs(registry, default)
+        self.assertIn('no loaderplugin registry found in spec', s.getvalue())
+
     def test_wrong(self):
         spec = {'calmjs_loaderplugin_registry': object()}
         with pretty_logging(stream=StringIO()) as s:

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -40,7 +40,7 @@ from calmjs.toolchain import dict_setget_dict
 from calmjs.toolchain import dict_update_overwrite_check
 from calmjs.toolchain import spec_update_loaderplugin_sourcepath_dict
 from calmjs.toolchain import spec_update_loaderplugin_registry
-from calmjs.toolchain import toolchain_spec_entries_compile
+from calmjs.toolchain import toolchain_spec_compile_entries
 
 from calmjs.toolchain import CLEANUP
 from calmjs.toolchain import SUCCESS
@@ -1228,7 +1228,7 @@ class ToolchainTestCase(unittest.TestCase):
         target4 = 'namespace.mod4.js'
 
         compile_bundle = partial(
-            toolchain_spec_entries_compile, self.toolchain,
+            toolchain_spec_compile_entries, self.toolchain,
             process_name='bundle')
 
         compile_bundle(spec, [

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -1362,6 +1362,31 @@ class NullToolchainTestCase(unittest.TestCase):
             'template.tmpl',
         )
 
+    def test_toolchain_naming_modname_source_to_target_loaderplugin(self):
+        s = Spec(calmjs_loaderplugin_registry=LoaderPluginRegistry(
+            'simloaders', _working_set=WorkingSet({'simloaders': [
+                'foo = calmjs.loaderplugin:LoaderPluginHandler',
+                'bar = calmjs.loaderplugin:LoaderPluginHandler',
+            ]})
+        ))
+        self.assertEqual(self.toolchain.modname_source_to_target(
+            s, 'example/module', '/tmp/example.module/src/example/module.js'),
+            'example/module.js',
+        )
+        self.assertEqual(self.toolchain.modname_source_to_target(
+            s, 'foo!example/module.txt', '/tmp/example.module/src/example'),
+            'example/module.txt',
+        )
+        self.assertEqual(self.toolchain.modname_source_to_target(
+            s, 'foo!bar!module.txt', '/tmp/example.module/src/example'),
+            'module.txt',
+        )
+        # baz not handled.
+        self.assertEqual(self.toolchain.modname_source_to_target(
+            s, 'foo!baz!bar!module.txt', '/tmp/example.module/src/example'),
+            'baz!bar!module.txt',
+        )
+
     def test_toolchain_gen_modname_source_target_modpath(self):
         spec = Spec()
         toolchain = self.toolchain

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -29,7 +29,7 @@ from calmjs.toolchain import Toolchain
 from calmjs.toolchain import NullToolchain
 from calmjs.toolchain import ES5Toolchain
 from calmjs.toolchain import dict_get
-from calmjs.toolchain import dict_key_update_overwrite_check
+from calmjs.toolchain import dict_update_overwrite_check
 from calmjs.toolchain import spec_update_plugins_sourcepath_dict
 from calmjs.toolchain import toolchain_spec_entries_compile
 
@@ -87,55 +87,40 @@ class DictGetTestCase(unittest.TestCase):
         self.assertIs(items['a_key'], a_key)
 
 
-class DictKeyGetUpdateTestCase(unittest.TestCase):
+class DictUpdateOverwriteTestCase(unittest.TestCase):
     """
     A function for updating specific dict/spec via a key, and ensure
     that any overwritten values are warned with the specified message.
     """
 
     def test_dict_key_update_overwrite_check_standard(self):
-        a = {}
-        a['base_key'] = {'k1': 'v1'}
-        mapping = {'k2': 'v2'}
-        with pretty_logging(stream=StringIO()) as s:
-            dict_key_update_overwrite_check(a, 'base_key', mapping)
-        self.assertEqual(s.getvalue(), '')
-        self.assertEqual(a['base_key'], {'k1': 'v1', 'k2': 'v2'})
+        a = {'k1': 'v1'}
+        b = {'k2': 'v2'}
+        self.assertEqual([], dict_update_overwrite_check(a, b))
+        self.assertEqual(a, {'k1': 'v1', 'k2': 'v2'})
 
     def test_dict_key_update_overwrite_check_no_update(self):
-        a = {}
-        a['base_key'] = {'k1': 'v1'}
-        mapping = {'k1': 'v1'}
-        with pretty_logging(stream=StringIO()) as s:
-            dict_key_update_overwrite_check(a, 'base_key', mapping)
-        self.assertEqual(s.getvalue(), '')
-        self.assertEqual(a['base_key'], {'k1': 'v1'})
+        a = {'k1': 'v1'}
+        b = {'k1': 'v1'}
+        self.assertEqual([], dict_update_overwrite_check(a, b))
+        self.assertEqual(a, {'k1': 'v1'})
 
     def test_dict_key_update_overwrite_check_overwritten_single(self):
-        a = {}
-        a['base_key'] = {'k1': 'v1'}
-        mapping = {'k1': 'v2'}
-        with pretty_logging(stream=StringIO()) as s:
-            dict_key_update_overwrite_check(a, 'base_key', mapping)
-        self.assertIn(
-            "base_key['k1'] is being rewritten from 'v1' to 'v2'; "
-            "configuration may be in an invalid state.",
-            s.getvalue())
-        self.assertEqual(a['base_key'], {'k1': 'v2'})
+        a = {'k1': 'v1'}
+        b = {'k1': 'v2'}
+        self.assertEqual([
+            ('k1', 'v1', 'v2'),
+        ], dict_update_overwrite_check(a, b))
+        self.assertEqual(a, {'k1': 'v2'})
 
     def test_dict_key_update_overwrite_check_overwritten_multi(self):
-        a = {}
-        a['base_key'] = {'k1': 'v1', 'k2': 'v2'}
-        mapping = {'k1': 'v2', 'k2': 'v4'}
-        with pretty_logging(stream=StringIO()) as s:
-            dict_key_update_overwrite_check(a, 'base_key', mapping, 'oops.')
-        self.assertIn(
-            "base_key['k1'] is being rewritten from 'v1' to 'v2'; oops.",
-            s.getvalue())
-        self.assertIn(
-            "base_key['k2'] is being rewritten from 'v2' to 'v4'; oops.",
-            s.getvalue())
-        self.assertEqual(a['base_key'], {'k1': 'v2', 'k2': 'v4'})
+        a = {'k1': 'v1', 'k2': 'v2'}
+        b = {'k1': 'v2', 'k2': 'v4'}
+        self.assertEqual([
+            ('k1', 'v1', 'v2'),
+            ('k2', 'v2', 'v4'),
+        ], sorted(dict_update_overwrite_check(a, b)))
+        self.assertEqual(a, {'k1': 'v2', 'k2': 'v4'})
 
 
 class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -37,7 +37,7 @@ from calmjs.toolchain import ToolchainSpecCompileEntry
 from calmjs.toolchain import dict_setget
 from calmjs.toolchain import dict_setget_dict
 from calmjs.toolchain import dict_update_overwrite_check
-from calmjs.toolchain import spec_update_plugins_sourcepath_dict
+from calmjs.toolchain import spec_update_loaderplugins_sourcepath_dict
 from calmjs.toolchain import toolchain_spec_entries_compile
 from calmjs.toolchain import spec_extend_loaderplugin_registries
 from calmjs.toolchain import spec_update_loaderplugins_handlers
@@ -154,7 +154,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
             'standard.module': 'standard.module',
         }
         spec = {}
-        spec_update_plugins_sourcepath_dict(
+        spec_update_loaderplugins_sourcepath_dict(
             spec, sourcepath_dict, 'sourcepath_key', 'plugins_key')
         self.assertEqual(spec, {
             'plugins_key': {},
@@ -171,7 +171,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
         base_map = {}
         spec = {'sourcepath_key': base_map}
 
-        spec_update_plugins_sourcepath_dict(
+        spec_update_loaderplugins_sourcepath_dict(
             spec, sourcepath_dict, 'sourcepath_key', 'plugins_key')
         self.assertIs(spec['sourcepath_key'], base_map)
         self.assertEqual(base_map, {
@@ -185,7 +185,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
         }
         spec = {}
 
-        spec_update_plugins_sourcepath_dict(
+        spec_update_loaderplugins_sourcepath_dict(
             spec, sourcepath_dict, 'sourcepath_key', 'plugins_key')
         self.assertEqual(spec, {
             'plugins_key': {
@@ -200,7 +200,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
             },
         })
 
-        spec_update_plugins_sourcepath_dict(spec, {
+        spec_update_loaderplugins_sourcepath_dict(spec, {
             'text!argument2': 'some/text/file2.txt',
         }, 'sourcepath_key', 'plugins_key')
 

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -178,10 +178,13 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
             'standard/module': 'standard/module',
         })
 
-    def test_modules(self):
+    def test_various_modules(self):
         sourcepath_dict = {
             'plugin/module!argument': 'some/filesystem/path',
+            'plugin/module!css!argument': 'some/style/file.css',
             'text!argument': 'some/text/file.txt',
+            'css?module!target.css': 'some/stylesheet/target.css',
+            'css!main.css': 'some/stylesheet/main.css',
         }
         spec = {}
 
@@ -191,15 +194,21 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
             'plugins_key': {
                 'plugin/module': {
                     'plugin/module!argument': 'some/filesystem/path',
+                    'plugin/module!css!argument': 'some/style/file.css',
                 },
                 'text': {
                     'text!argument': 'some/text/file.txt',
+                },
+                'css': {
+                    'css?module!target.css': 'some/stylesheet/target.css',
+                    'css!main.css': 'some/stylesheet/main.css',
                 },
             },
             'sourcepath_key': {
             },
         })
 
+        # subsequent update will do update, not overwrite.
         spec_update_loaderplugins_sourcepath_dict(spec, {
             'text!argument2': 'some/text/file2.txt',
         }, 'sourcepath_key', 'plugins_key')

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -241,6 +241,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
 
     def test_various_modules(self):
         sourcepath_dict = {
+            'plugin/module': 'path/to/plugin/module',
             'plugin/module!argument': 'some/filesystem/path',
             'plugin/module!css!argument': 'some/style/file.css',
             'text!argument': 'some/text/file.txt',
@@ -268,6 +269,7 @@ class SpecUpdatePluginsSourcepathDictTestCase(unittest.TestCase):
                 },
             },
             'sourcepath_key': {
+                'plugin/module': 'path/to/plugin/module',
             },
         })
 
@@ -1375,6 +1377,7 @@ class NullToolchainTestCase(unittest.TestCase):
             'simloaders', _working_set=WorkingSet({'simloaders': [
                 'foo = calmjs.loaderplugin:LoaderPluginHandler',
                 'bar = calmjs.loaderplugin:LoaderPluginHandler',
+                'py/loader = calmjs.loaderplugin:LoaderPluginHandler',
             ]})
         ))
         self.assertEqual(self.toolchain.modname_source_to_target(
@@ -1393,6 +1396,15 @@ class NullToolchainTestCase(unittest.TestCase):
         self.assertEqual(self.toolchain.modname_source_to_target(
             s, 'foo!baz!bar!module.txt', '/tmp/example.module/src/example'),
             'baz!bar!module.txt',
+        )
+        # python provided loaders
+        self.assertEqual(self.toolchain.modname_source_to_target(
+            s, 'py/module', '/tmp/py.module/py/module.js'),
+            'py/module.js',
+        )
+        self.assertEqual(self.toolchain.modname_source_to_target(
+            s, 'py/loader', '/tmp/py.module/py/loader.js'),
+            'py/loader.js',
         )
 
     def test_toolchain_gen_modname_source_target_modpath(self):

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -255,6 +255,15 @@ def dict_update_overwrite_check(base, fresh):
     return result
 
 
+# Spec functions for interfacing with loaderplugins
+#
+# The following functions (named in the format spec_*_loaderplugins_*)
+# are helpers for extracting and filtering the mappings for interfacing
+# with the loaderplugin helpers through the registry system.  These
+# helpers are here as they are part of the toolchain, not as part of the
+# loaderplugin module due to that module being the part that couples
+# tightly with npm.
+
 def spec_update_loaderplugins_sourcepath_dict(
         spec, sourcepath_dict, sourcepath_dict_key,
         loaderplugins_sourcepath_dict_key):

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -261,7 +261,8 @@ def dict_update_overwrite_check(base, fresh):
 # loaderplugin module due to that module being the part that couples
 # tightly with npm.
 
-def spec_update_loaderplugin_registry(spec):
+def spec_update_loaderplugin_registry(spec, default=BaseLoaderPluginRegistry(
+        '<default_loaderplugins>')):
     """
     Resolve a BasePluginLoaderRegistry instance from spec, and update
     spec[CALMJS_LOADERPLUGIN_REGISTRY] with that value before returning
@@ -284,8 +285,7 @@ def spec_update_loaderplugin_registry(spec):
     else:
         logger.info(
             'no loaderplugin registry found in spec; using default fallback')
-    spec[CALMJS_LOADERPLUGIN_REGISTRY] = registry = BaseLoaderPluginRegistry(
-        '<default_loaderplugins>')
+    spec[CALMJS_LOADERPLUGIN_REGISTRY] = registry = default
 
     return registry
 

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -1097,7 +1097,7 @@ class Toolchain(BaseDriver):
         """
 
         loaderplugin_registry = spec.get(CALMJS_LOADERPLUGIN_REGISTRY)
-        if loaderplugin_registry:
+        if '!' in modname and loaderplugin_registry:
             handler = loaderplugin_registry.get(modname)
             if handler:
                 return handler.modname_source_to_target(

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -1231,8 +1231,8 @@ class ES5Toolchain(Toolchain):
     around, using the es5 Unparser, pretty printer version.
     """
 
-    def __init__(self):
-        super(ES5Toolchain, self).__init__()
+    def __init__(self, *a, **kw):
+        super(ES5Toolchain, self).__init__(*a, **kw)
 
     def setup_transpiler(self):
         self.transpiler = pretty_printer()

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -107,7 +107,8 @@ __all__ = [
 
     'toolchain_spec_entries_compile', 'ToolchainSpecCompileEntry',
 
-    'spec_update_loaderplugins_sourcepath_dict',
+    'spec_update_loaderplugin_sourcepath_dict',
+    'spec_update_loaderplugin_registry',
 
     'CALMJS_TOOLCHAIN_ADVICE',
 
@@ -254,7 +255,7 @@ def dict_update_overwrite_check(base, fresh):
 
 # Spec functions for interfacing with loaderplugins
 #
-# The following functions (named in the format spec_*_loaderplugins_*)
+# The following functions (named in the format spec_*_loaderplugin_*)
 # are helpers for extracting and filtering the mappings for interfacing
 # with the loaderplugin helpers through the registry system.  These
 # helpers are here as they are part of the toolchain, not as part of the
@@ -290,9 +291,9 @@ def spec_update_loaderplugin_registry(spec, default=BaseLoaderPluginRegistry(
     return registry
 
 
-def spec_update_loaderplugins_sourcepath_dict(
+def spec_update_loaderplugin_sourcepath_dict(
         spec, sourcepath_dict, sourcepath_dict_key,
-        loaderplugins_sourcepath_dict_key):
+        loaderplugin_sourcepath_dict_key):
     """
     Take an existing spec and a sourcepath mapping (that could be
     produced via calmjs.dist.*_module_registry_dependencies functions)
@@ -302,7 +303,7 @@ def spec_update_loaderplugins_sourcepath_dict(
     For the parts with loader plugin syntax (i.e. modnames (keys) that
     contain a '!' character), they are instead stored under a different
     mapping under its own mapping identified by the plugin_name.  The
-    mapping under loaderplugins_sourcepath_dict_key will contain all
+    mapping under loaderplugin_sourcepath_dict_key will contain all
     mappings of this type.
 
     The resolution for the handlers will be done through the loader
@@ -326,7 +327,7 @@ def spec_update_loaderplugins_sourcepath_dict(
         'module': 'something',
     }
 
-    spec[loaderplugins_sourcepath_dict_key] = {
+    spec[loaderplugin_sourcepath_dict_key] = {
         'plugin': {
             'plugin!inner': 'inner',
             'plugin!other': 'other',
@@ -356,8 +357,8 @@ def spec_update_loaderplugins_sourcepath_dict(
     default = dict_setget_dict(spec, sourcepath_dict_key)
     registry = spec_update_loaderplugin_registry(spec)
 
-    # it is more loaderplugins_sourcepath_maps
-    plugins = dict_setget_dict(spec, loaderplugins_sourcepath_dict_key)
+    # it is more loaderplugin_sourcepath_maps
+    plugins = dict_setget_dict(spec, loaderplugin_sourcepath_dict_key)
 
     for modname, sourcepath in sourcepath_dict.items():
         parts = modname.split('!', 1)

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -1095,6 +1095,13 @@ class Toolchain(BaseDriver):
         Called by generator method `_gen_modname_source_target_modpath`.
         """
 
+        loaderplugin_registry = spec.get(CALMJS_LOADERPLUGIN_REGISTRY)
+        if loaderplugin_registry:
+            handler = loaderplugin_registry.get(modname)
+            if handler:
+                return handler.modname_source_to_target(
+                    self, spec, modname, source)
+
         if (source.endswith(self.filename_suffix) and
                 not modname.endswith(self.filename_suffix)):
             return modname + self.filename_suffix

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -106,7 +106,7 @@ __all__ = [
 
     'toolchain_spec_entries_compile', 'ToolchainSpecCompileEntry',
 
-    'spec_update_plugins_sourcepath_dict',
+    'spec_update_loaderplugins_sourcepath_dict',
     'spec_extend_loaderplugin_registries',
     'spec_update_loaderplugins_handlers',
 
@@ -255,7 +255,7 @@ def dict_update_overwrite_check(base, fresh):
     return result
 
 
-def spec_update_plugins_sourcepath_dict(
+def spec_update_loaderplugins_sourcepath_dict(
         spec, sourcepath_dict, sourcepath_dict_key,
         loaderplugins_sourcepath_dict_key):
     """
@@ -348,7 +348,7 @@ def spec_update_loaderplugins_handlers(
     the spec.
 
     The sourcepath mappings are expected to be produced and assigned
-    through the spec_update_plugins_sourcepath_dict function.
+    through the spec_update_loaderplugins_sourcepath_dict function.
     """
 
     # extract required values

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -102,7 +102,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     'AdviceRegistry', 'Spec', 'Toolchain', 'null_transpiler',
 
-    'dict_get', 'dict_update_overwrite_check',
+    'dict_setget', 'dict_setget_dict', 'dict_update_overwrite_check',
 
     'toolchain_spec_entries_compile', 'ToolchainSpecCompileEntry',
 
@@ -223,9 +223,13 @@ def _deprecation_warning(msg):
     logger.warning(msg)
 
 
-def dict_get(d, key):
-    value = d[key] = d.get(key, {})
+def dict_setget(d, key, value):
+    value = d[key] = d.get(key, value)
     return value
+
+
+def dict_setget_dict(d, key):
+    return dict_setget(d, key, {})
 
 
 def dict_update_overwrite_check(base, fresh):
@@ -260,7 +264,7 @@ def spec_update_plugins_sourcepath_dict(
     encoded mapping of transpiled file back to its original.
     """
 
-    default = dict_get(spec, sourcepath_dict_key)
+    default = dict_setget_dict(spec, sourcepath_dict_key)
     for modname, sourcepath in sourcepath_dict.items():
         parts = modname.split('!', 1)
         if len(parts) == 1:
@@ -269,8 +273,8 @@ def spec_update_plugins_sourcepath_dict(
             continue
 
         plugin_name, arguments = parts
-        plugins = dict_get(spec, plugins_sourcepath_dict_key)
-        plugin = dict_get(plugins, plugin_name)
+        plugins = dict_setget_dict(spec, plugins_sourcepath_dict_key)
+        plugin = dict_setget_dict(plugins, plugin_name)
         plugin[modname] = sourcepath
 
 

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -276,6 +276,8 @@ def spec_update_loaderplugins_sourcepath_dict(
         'module': 'something',
         'plugin!inner': 'inner',
         'plugin!other': 'other',
+        'plugin?query!question': 'question',
+        'plugin!plugin2!target': 'target',
     }
 
     The following will be stored under the following keys in spec:
@@ -288,11 +290,16 @@ def spec_update_loaderplugins_sourcepath_dict(
         'plugin': {
             'plugin!inner': 'inner',
             'plugin!other': 'other',
+            'plugin?query!question': 'question',
+            'plugin!plugin2!target': 'target',
         },
     }
 
     The goal of this function is to aid in processing each of the plugin
-    types by batch.
+    types by batch, one level at a time.  It is up to the handler itself
+    to trigger further lookups as there are implementations of loader
+    plugins that do not respect the chaining mechanism, thus a generic
+    lookup done at once may not be suitable.
 
     Note that nested loaderplugins are not handled as the internal
     syntax are generally proprietary to the outer plugin.
@@ -314,7 +321,9 @@ def spec_update_loaderplugins_sourcepath_dict(
             default[modname] = sourcepath
             continue
 
-        plugin_name, arguments = parts
+        plugin_raw, arguments = parts
+        plugin_globs = plugin_raw.split('?')
+        plugin_name = plugin_globs[0]
         plugin = dict_setget_dict(plugins, plugin_name)
         plugin[modname] = sourcepath
 


### PR DESCRIPTION
Ensure that this is done, and working for both requirejs and webpack in a way such that it is also possible for packages to declare their own entries or registries, so they can have explicit control over which plugins they may want for some specific names, if required.

At the very least, have the text loader plugin be declared and usable for both of these artifact builders.