### PR TITLE
Have the argument parsing log warnings

### DIFF
--- a/src/calmjs/cli.py
+++ b/src/calmjs/cli.py
@@ -232,9 +232,7 @@ class PackageManagerDriver(NodeDriver):
                 }
             )
             warnings.warn(msg, RuntimeWarning)
-            # Yes there may be duplicates, but warnings are governed
-            # differently.
-            logger.warning(msg)
+
         scope_vars.update(inst._aliases)
         return inst
 

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -87,9 +87,11 @@ _reset_global_runtime_attrs()
 
 def _initialize_global_runtime_attrs(**kwargs):
     debug = kwargs.pop('debug')
-    verbosity = min(max(kwargs.pop('verbose') - kwargs.pop('quiet'), -2), 2)
+    verbose = kwargs.pop('verbose')
+    quiet = kwargs.pop('quiet')
+    verbosity = min(max(verbose - quiet, -2), 2)
     log_level = levels.get(verbosity)
-    bootstrap_log_level = levels.get(max(-2, verbosity - 1))
+    bootstrap_log_level = levels.get(min(max(verbose - quiet - 1, -2), 2))
     _global_runtime_attrs.update({
         'debug': debug,
         'log_level': log_level,

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -1115,6 +1115,10 @@ def main(args=None, runtime_cls=CalmJSRuntime):
             # finally, ensure all captured records (thus far) are logged
             for record in records:
                 logger.warning(record.message)
+                logger.debug(
+                    '%s triggered at %s:%s', record.category.__name__,
+                    record.filename, record.lineno,
+                )
 
         # Running this outside of the logger, as the BaseRuntime will do
         # its logging.

--- a/src/calmjs/tests/test_cli.py
+++ b/src/calmjs/tests/test_cli.py
@@ -489,28 +489,7 @@ class CliDriverTestCase(unittest.TestCase):
         inst = Driver.create()
         self.assertTrue(isinstance(inst, Driver))
 
-    def test_module_level_driver_create_for_module_vars(self):
-        class Driver(cli.PackageManagerDriver):
-            def __init__(self, **kw):
-                kw['pkg_manager_bin'] = 'mgr'
-                super(Driver, self).__init__(**kw)
-
-        values = {}
-
-        with warnings.catch_warnings():
-            # Don't spat out stderr
-            warnings.simplefilter('ignore')
-            with pretty_logging(stream=mocks.StringIO()) as err:
-                Driver.create_for_module_vars(values)
-            self.assertIn(
-                "Unable to locate the 'mgr' binary or runtime", err.getvalue())
-
-        # Normally, these will be global names.
-        self.assertIn('mgr_install', values)
-        self.assertIn('mgr_init', values)
-        self.assertIn('get_mgr_version', values)
-
-    def test_create_for_module_vars_warning(self):
+    def test_create_for_module_vars_and_warning(self):
         stub_os_environ(self)
         tmpdir = mkdtemp(self)
         values = {}
@@ -523,17 +502,17 @@ class CliDriverTestCase(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            with pretty_logging(stream=mocks.StringIO()) as err:
-                driver = MgrDriver.create_for_module_vars(values)
-            self.assertIn(
-                "Unable to locate the 'mgr' binary or runtime", err.getvalue())
-
+            driver = MgrDriver.create_for_module_vars(values)
             self.assertTrue(issubclass(w[-1].category, RuntimeWarning))
             self.assertIn(
                 "Unable to locate the 'mgr' binary or runtime",
                 str(w[-1].message))
 
         self.assertTrue(isinstance(driver, MgrDriver))
+        # Normally, these will be global names.
+        self.assertIn('mgr_install', values)
+        self.assertIn('mgr_init', values)
+        self.assertIn('get_mgr_version', values)
 
     # Should really put more tests of these kind in here, but the more
     # concrete implementations have done so.  This weird version here

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -10,6 +10,7 @@ from os.path import join
 from os.path import exists
 from logging import DEBUG
 from logging import INFO
+from logging import WARNING
 
 import pkg_resources
 
@@ -92,12 +93,12 @@ class BaseRuntimeTestCase(unittest.TestCase):
         bt = runtime.BaseRuntime()
         fake_parse.parse_known_args = bt.argparser.parse_known_args
         bt.argparser.parse_known_args = fake_parse
+
         with pretty_logging(stream=mocks.StringIO()) as s:
             bt(['-v'])
-
         self.assertIn("WARNING calmjs.runtime fake deprecation", s.getvalue())
 
-    def test_argparse_warning(self):
+    def test_argparse_levels(self):
         stub_stdouts(self)
         bt = runtime.BaseRuntime()
         bt(['-vvv', '-qq', '-d'])
@@ -107,6 +108,17 @@ class BaseRuntimeTestCase(unittest.TestCase):
         self.assertEqual(rt.verbosity, 1)
         self.assertEqual(rt.debug, 1)
         self.assertEqual(rt.log_level, INFO)
+        self.assertEqual(rt.bootstrap_log_level, WARNING)
+
+    def test_argparse_bootstrap_debug(self):
+        stub_stdouts(self)
+        bt = runtime.BaseRuntime()
+        bt(['-vvv'])
+
+        # should be a global state.
+        rt = runtime.BaseRuntime()
+        self.assertEqual(rt.log_level, DEBUG)
+        self.assertEqual(rt.bootstrap_log_level, DEBUG)
 
     def test_bad_global_flags(self):
         stub_stdouts(self)

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -241,6 +241,23 @@ class BaseRuntimeTestCase(unittest.TestCase):
         err = sys.stderr.getvalue()
         self.assertNotIn('Traceback', err)
         self.assertIn('this runtime is deprecated', err)
+        self.assertNotIn('DeprecationWarning triggered at', err)
+
+    def test_runtime_entry_point_preparse_warning_verbose_debug_logged(self):
+        stub_stdouts(self)
+        working_set = mocks.WorkingSet({'calmjs.runtime': [
+            'deprecated = calmjs.tests.test_runtime:deprecated',
+        ]})
+        with self.assertRaises(SystemExit):
+            # use the verbose flag to increase the log level
+            runtime.main(
+                ['-vvv', 'deprecated'],
+                runtime_cls=lambda: runtime.Runtime(working_set=working_set)
+            )
+        err = sys.stderr.getvalue()
+        self.assertNotIn('Traceback', err)
+        self.assertIn('this runtime is deprecated', err)
+        self.assertIn('DeprecationWarning triggered at', err)
 
     def test_runtime_main_with_broken_runtime(self):
         stub_stdouts(self)


### PR DESCRIPTION
This also changes how the package manager runtime no longer generate a log entry, and fixes the bootstrap logging so that debug logs are capable to be shown.