### PR TITLE
Artifact registry refactor plus runtime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,6 +258,7 @@ command-line utility will become available within there.
 
     positional arguments:
       <command>
+        artifact     helpers for the management of artifacts
         npm          npm support for the calmjs framework
         yarn         yarn support for the calmjs framework
 
@@ -643,9 +644,16 @@ file.  The generated artifact files will reside in the
 package.  An accompanied ``calmjs_artifacts.json`` file will also be
 generated, listing the versions of the various Python packages that were
 involved with construction of that artifact, and the version of binary
-that was used for the task.  Note that the argument
-``build_calmjs_artifacts`` must be to ``True`` to enable this build
-functionality.
+that was used for the task.
+
+When the ``build_calmjs_artifacts`` is set to ``True``, the hook for
+automatic generation of these artifacts through the ``setup.py build``
+step will enabled.  This is useful for automatically bundling the
+artifact file with a release such as Python wheels (e.g. running
+``setup.py bdist_wheel`` will also build the declared artifacts.
+Otherwise, this step can be manually invoked using
+``setup.py build_calmjs_artifacts`` or through the
+``calmjs artifact build`` tool.
 
 
 Troubleshooting

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,12 @@ setup(
             'calmjs = calmjs.runtime:main',
         ],
         'calmjs.runtime': [
+            'artifact = calmjs.runtime:artifact',
             'npm = calmjs.npm:npm.runtime',
             'yarn = calmjs.yarn:yarn.runtime',
+        ],
+        'calmjs.runtime.artifact': [
+            'build = calmjs.runtime:artifact_build',
         ],
         'distutils.commands': [
             'npm = calmjs.npm:npm',
@@ -92,6 +96,7 @@ setup(
         ],
         'calmjs.reserved': [
             'calmjs.artifacts = calmjs',
+            'calmjs.artifacts.tests = calmjs.dev',
             'calmjs.dev.module = calmjs.dev',
             'calmjs.dev.module.tests = calmjs.dev',
             'calmjs.extras_keys = calmjs',

--- a/src/calmjs/README.rst
+++ b/src/calmjs/README.rst
@@ -46,6 +46,12 @@ registry
     Root registry class.  Inherits from base.  Should not inherit from
     anything else.
 
+command
+    Provides the primitives for distutils/setuptools integration.  It
+    should not inherit from anything but rather the downstream users
+    should compose the instances with whatever it needs, with data
+    provided by the registry.
+
 indexer
     Contains a microregistry and a number of functions for generation
     of mappings of files within modules in Python packages for the
@@ -80,24 +86,16 @@ cli
     its own shell.  This latter part could be exposed as the runtime
     library.
 
-runtime
-    The module that provides the classes and functions that aid with
-    providing the entry point into calmjs from cli and elsewhere.
-    Supports the generation of the texts for users from the shell.
-
-command
-    Provides the primitive package manager command.  While it doesn't
-    really inherit from anything here, implementations will likely
-    inherit from dist for helpers, cli for the actual cli interfacing
-    part for the underlying binary for the command, and runtime for the
-    help tests.  The classes will hold onto an instance of a cli Driver
-    and also the appropriate runtime constructed using that.
-
 artifact
     Defines all artifact integration functionalities; includes the
     related registries, makes use of the dist and command modules for
     the resolution of dependencies of packages and hooks into the
     setuptools infrastructure.
+
+runtime
+    The module that provides the classes and functions that aid with
+    providing the entry point into calmjs from cli and elsewhere.
+    Supports the generation of the texts for users from the shell.
 
 npm
     The npm specific tools.  Whole module can in theory be generated

--- a/src/calmjs/argparse.py
+++ b/src/calmjs/argparse.py
@@ -132,6 +132,21 @@ class Version(Action):
         sys.exit(0)
 
 
+class MultiChoice(object):
+
+    def __init__(self, choices=(), sep=','):
+        self.__original = choices
+        self.__choices = set(choices)
+        self.__sep = sep
+
+    def __contains__(self, other):
+        return not (set(other.split(self.__sep)) - self.__choices)
+
+    def __iter__(self):
+        for i in self.__original:
+            yield i
+
+
 class StoreDelimitedListBase(Action):
 
     def __init__(self, option_strings, dest, sep=',', maxlen=None, **kw):
@@ -140,6 +155,8 @@ class StoreDelimitedListBase(Action):
         kw['nargs'] = 1
         kw['const'] = None
         default = kw.get('default')
+        if 'choices' in kw:
+            kw['choices'] = MultiChoice(choices=kw['choices'], sep=sep)
         if default is not None and not isinstance(default, (tuple, list)):
             raise ValueError(
                 'provided default for store delimited list must be a list or '

--- a/src/calmjs/argparse.py
+++ b/src/calmjs/argparse.py
@@ -24,6 +24,10 @@ ATTR_INFO = '_calmjs_runtime_info'
 ATTR_ROOT_PKG = '_calmjs_root_pkg_name'
 
 
+def metavar(name):
+    return '<' + name.lower() + '>'
+
+
 class Namespace(argparse.Namespace):
     """
     This implementation retains existing parsed value for matched types,

--- a/src/calmjs/artifact.py
+++ b/src/calmjs/artifact.py
@@ -424,7 +424,13 @@ class BaseArtifactRegistry(BaseRegistry):
 
     def update_artifact_metadata(self, package_name, new_metadata):
         metadata = self.get_artifact_metadata(package_name)
-        metadata_filename = self.metadata.get(package_name)
+        metadata_filename = self.metadata.get(package_name, NotImplemented)
+        if metadata_filename is NotImplemented:
+            logger.info(
+                "package '%s' has not declare any artifacts; not applying "
+                "updates to metadata information", package_name)
+            return
+
         artifacts = metadata[ARTIFACT_BASENAME] = metadata.get(
             ARTIFACT_BASENAME, {})
         artifacts.update(new_metadata)

--- a/src/calmjs/cli.py
+++ b/src/calmjs/cli.py
@@ -62,7 +62,7 @@ def get_bin_version_str(bin_path, version_flag='-v', kw={}):
             "'%s':", bin_path
         )
         return None
-    logger.info("found '%s' version '%s'", bin_path, version_str)
+    logger.info("'%s' is version '%s'", bin_path, version_str)
     return version_str
 
 

--- a/src/calmjs/command.py
+++ b/src/calmjs/command.py
@@ -180,6 +180,8 @@ class BuildArtifactCommand(Command):
         If finalization is needed.
         """
 
+    # TODO make use of cli_driver rather than probing for registry
+
     @use_distutils_logger()
     def run(self):
         if self.dry_run:

--- a/src/calmjs/command.py
+++ b/src/calmjs/command.py
@@ -184,4 +184,4 @@ class BuildArtifactCommand(Command):
     def run(self):
         if self.dry_run:
             return
-        get('calmjs.artifacts').build_artifacts(self.distribution.get_name())
+        get('calmjs.artifacts').process_package(self.distribution.get_name())

--- a/src/calmjs/registry.py
+++ b/src/calmjs/registry.py
@@ -94,11 +94,15 @@ class Registry(BaseRegistry):
 
         entry_point = self._entry_points.get(name)
         if not entry_point:
+            logger.debug("'%s' does not resolve to a registry", name)
             return
 
         try:
             cls = entry_point.load()
         except ImportError:
+            logger.debug(
+                "ImportError '%s' from '%s'",
+                entry_point, entry_point.dist)
             return
 
         logger.debug(

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -903,8 +903,10 @@ class BaseArtifactRegistryRuntime(BaseRuntime):
     def init_argparser(self, argparser):
         super(BaseArtifactRegistryRuntime, self).init_argparser(argparser)
         argparser.add_argument(
-            'package_names', help='names of the python package to use',
-            metavar='package_name', nargs='+',
+            'package_names', metavar='package_name', nargs='+',
+            help='names of the python package to generate artifacts for; '
+                 'note that the metadata directory for the specified '
+                 'packages must be writable',
         )
 
     def run(self, argparser=None, package_names=[], *a, **kwargs):

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -24,6 +24,7 @@ from calmjs.argparse import StoreDelimitedList
 from calmjs.argparse import Version
 from calmjs.argparse import ATTR_INFO
 from calmjs.argparse import ATTR_ROOT_PKG
+from calmjs.argparse import metavar
 from calmjs.exc import RuntimeAbort
 from calmjs.registry import get
 from calmjs.toolchain import Spec
@@ -692,7 +693,7 @@ class ToolchainRuntime(DriverRuntime):
 
         argparser.add_argument(
             '--export-target', dest=EXPORT_TARGET,
-            metavar=EXPORT_TARGET,
+            metavar=metavar(EXPORT_TARGET),
             default=default,
             help=help,
         )
@@ -718,7 +719,7 @@ class ToolchainRuntime(DriverRuntime):
         cwd = self.toolchain.join_cwd()
         argparser.add_argument(
             '--working-dir', dest=WORKING_DIR,
-            metavar=WORKING_DIR,
+            metavar=metavar(WORKING_DIR),
             default=cwd,
             help=help_template % {'explanation': explanation, 'cwd': cwd},
         )
@@ -739,7 +740,7 @@ class ToolchainRuntime(DriverRuntime):
 
         argparser.add_argument(
             '--build-dir', default=None, dest=BUILD_DIR,
-            metavar=BUILD_DIR, help=help,
+            metavar=metavar(BUILD_DIR), help=help,
         )
 
     def init_argparser_optional_advice(
@@ -757,7 +758,7 @@ class ToolchainRuntime(DriverRuntime):
         argparser.add_argument(
             '--optional-advice', default=default, required=False,
             dest=ADVICE_PACKAGES, action=StoreRequirementList,
-            metavar='advice[,advice[...]]',
+            metavar='<advice>[,<advice>[...]]',
             help=help
         )
 
@@ -903,7 +904,7 @@ class BaseArtifactRegistryRuntime(BaseRuntime):
     def init_argparser(self, argparser):
         super(BaseArtifactRegistryRuntime, self).init_argparser(argparser)
         argparser.add_argument(
-            'package_names', metavar='package_name', nargs='+',
+            'package_names', metavar=metavar('package'), nargs='+',
             help='names of the python package to generate artifacts for; '
                  'note that the metadata directory for the specified '
                  'packages must be writable',
@@ -946,7 +947,7 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
         argparser.add_argument(
             '--source-registry', default=default,
             dest=CALMJS_MODULE_REGISTRY_NAMES, action=StoreDelimitedList,
-            metavar='registry_name[,registry_name[...]]',
+            metavar='<registry>[,<registry>[...]]',
             help=help,
         )
 
@@ -973,7 +974,7 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
         argparser.add_argument(
             '--loaderplugin-registry', default=default,
             dest=CALMJS_LOADERPLUGIN_REGISTRY_NAME, action='store',
-            metavar='registry_name',
+            metavar=metavar('registry'),
             help=help,
         )
 
@@ -985,7 +986,7 @@ class SourcePackageToolchainRuntime(ToolchainRuntime):
 
         argparser.add_argument(
             SOURCE_PACKAGE_NAMES, help=help,
-            metavar='package_name', nargs='+',
+            metavar=metavar('package'), nargs='+',
         )
 
     def init_argparser(self, argparser):
@@ -1123,8 +1124,10 @@ class PackageManagerRuntime(DriverRuntime):
             argparser.add_argument(*args, help=desc, action='store_true')
 
         argparser.add_argument(
-            'package_names', help='names of the python package to use',
-            metavar='package_name', nargs='+',
+            'package_names', metavar=metavar('package'), nargs='+',
+            help="python packages to be used for the generation of '%s'" % (
+                self.cli_driver.pkgdef_filename,
+            ),
         )
 
     def run(self, argpaser=None, interactive=False, **kwargs):

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -903,12 +903,22 @@ class BaseArtifactRegistryRuntime(BaseRuntime):
 
     def init_argparser(self, argparser):
         super(BaseArtifactRegistryRuntime, self).init_argparser(argparser)
+        self.init_argparser_package_names(argparser)
+
+    def init_argparser_package_names(self, argparser, help=(
+                'names of the python package to generate artifacts for; '
+                'note that the metadata directory for the specified '
+                'packages must be writable')):
+        """
+        Default helper for setting up the package_names option.
+
+        This is separate so that subclasses are not assumed for the
+        purposes of artifact creation; they should consider modifying
+        the default help message to reflect the fact.
+        """
+
         argparser.add_argument(
-            'package_names', metavar=metavar('package'), nargs='+',
-            help='names of the python package to generate artifacts for; '
-                 'note that the metadata directory for the specified '
-                 'packages must be writable',
-        )
+            'package_names', metavar=metavar('package'), nargs='+', help=help)
 
     def run(self, argparser=None, package_names=[], *a, **kwargs):
         for package_name in package_names:

--- a/src/calmjs/testing/artifact.py
+++ b/src/calmjs/testing/artifact.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+from calmjs.toolchain import Spec
 from calmjs.toolchain import NullToolchain
 from calmjs.toolchain import TOOLCHAIN_BIN_PATH
 
@@ -11,3 +12,11 @@ class ArtifactToolchain(NullToolchain):
         spec[TOOLCHAIN_BIN_PATH] = 'artifact'
         with open(spec['export_target'], 'w') as fd:
             fd.write('\n'.join(spec['package_names']))
+
+
+# the generic builder
+def generic_builder(package_names, export_target):
+    return ArtifactToolchain(), Spec(
+        package_names=package_names,
+        export_target=export_target,
+    )

--- a/src/calmjs/tests/test_artifact.py
+++ b/src/calmjs/tests/test_artifact.py
@@ -469,7 +469,7 @@ class ArtifactRegistryBuildFailureTestCase(unittest.TestCase):
         # nothing dummy builder
         def nothing_builder(package_names, export_target):
             "does not produce an artifact"
-            return NullToolchain(), Spec()
+            return NullToolchain(), Spec(export_target=export_target)
 
         # inject dummy module and add cleanup
         mod = ModuleType('calmjs_testing_dummy')

--- a/src/calmjs/tests/test_artifact.py
+++ b/src/calmjs/tests/test_artifact.py
@@ -368,7 +368,7 @@ class ArtifactRegistryTestCase(unittest.TestCase):
         # quick check of the artifact metadata beforehand
         self.assertEqual({}, registry.get_artifact_metadata('app'))
 
-        registry.build_artifacts('app')
+        registry.process_package('app')
         complete = list(registry.resolve_artifacts_by_builder_compat(
             ['app'], 'complete'))
         partial = list(registry.resolve_artifacts_by_builder_compat(
@@ -444,7 +444,7 @@ class ArtifactRegistryTestCase(unittest.TestCase):
             self, artifact, 'get_bin_version_str', version)
         registry = ArtifactRegistry('calmjs.artifacts', _working_set=mock_ws)
 
-        registry.build_artifacts('app')
+        registry.process_package('app')
         self.assertEqual(3, len(registry.get_artifact_metadata('app')[
             'calmjs_artifacts']))
         self.assertIn('extra.js', registry.get_artifact_metadata('app')[
@@ -519,7 +519,7 @@ class ArtifactRegistryBuildFailureTestCase(unittest.TestCase):
 
     def test_build_artifacts_logs_and_failures(self):
         with pretty_logging(stream=mocks.StringIO()) as stream:
-            self.registry.build_artifacts('app')
+            self.registry.process_package('app')
 
         log = stream.getvalue()
         self.assertIn(
@@ -542,7 +542,7 @@ class ArtifactRegistryBuildFailureTestCase(unittest.TestCase):
             pass
 
         with pretty_logging(stream=mocks.StringIO()) as stream:
-            self.registry.build_artifacts('app')
+            self.registry.process_package('app')
 
         log = stream.getvalue()
         self.assertIn(
@@ -558,21 +558,21 @@ class ArtifactRegistryBuildFailureTestCase(unittest.TestCase):
             pass
 
         with pretty_logging(stream=mocks.StringIO()) as stream:
-            self.registry.build_artifacts('bad')
+            self.registry.process_package('bad')
 
         log = stream.getvalue()
         self.assertIn("its dirname does not lead to a directory", log)
 
     def test_malformed_builder_handling(self):
         with pretty_logging(stream=mocks.StringIO()) as stream:
-            self.registry.build_artifacts('malformed')
+            self.registry.process_package('malformed')
 
         log = stream.getvalue()
         self.assertIn("failed to produce a valid toolchain and spec", log)
 
     def test_artifact_generation_failure(self):
         with pretty_logging(stream=mocks.StringIO()) as stream:
-            self.registry.build_artifacts('nothing')
+            self.registry.process_package('nothing')
 
         log = stream.getvalue()
         self.assertIn(
@@ -583,7 +583,7 @@ class ArtifactRegistryBuildFailureTestCase(unittest.TestCase):
 
     def test_no_declaration(self):
         with pretty_logging(stream=mocks.StringIO()) as stream:
-            self.registry.build_artifacts('undeclared')
+            self.registry.process_package('undeclared')
 
         log = stream.getvalue()
         self.assertIn(

--- a/src/calmjs/tests/test_artifact.py
+++ b/src/calmjs/tests/test_artifact.py
@@ -29,15 +29,7 @@ from calmjs.toolchain import Spec
 
 from calmjs.testing import utils
 from calmjs.testing import mocks
-from calmjs.testing.toolchain import ArtifactToolchain
-
-
-# the generic builder
-def generic_builder(package_names, export_target):
-    return ArtifactToolchain(), Spec(
-        package_names=package_names,
-        export_target=export_target,
-    )
+from calmjs.testing.artifact import generic_builder
 
 
 class IntegrationTestCase(unittest.TestCase):
@@ -422,7 +414,7 @@ class ArtifactRegistryTestCase(unittest.TestCase):
                 'artifact.js': {
                     'builder': 'calmjs_testing_dummy:complete',
                     'toolchain_bases': [
-                        {'calmjs.testing.toolchain:ArtifactToolchain': {
+                        {'calmjs.testing.artifact:ArtifactToolchain': {
                             'project_name': 'calmjs',
                             'version': '1.0',
                         }},
@@ -440,7 +432,7 @@ class ArtifactRegistryTestCase(unittest.TestCase):
                 'partial.js': {
                     'builder': 'calmjs_testing_dummy:partial',
                     'toolchain_bases': [
-                        {'calmjs.testing.toolchain:ArtifactToolchain': {
+                        {'calmjs.testing.artifact:ArtifactToolchain': {
                             'project_name': 'calmjs',
                             'version': '1.0'}},
                         {'calmjs.toolchain:NullToolchain': {

--- a/src/calmjs/tests/test_artifact.py
+++ b/src/calmjs/tests/test_artifact.py
@@ -282,13 +282,13 @@ class ArtifactRegistryTestCase(unittest.TestCase):
 
         with pretty_logging(stream=mocks.StringIO()) as stream:
             registry.register_entry_point(s1)
-            # normal registry usage shouldn't do this.
+            # normal registry usage shouldn't be able to do this.
             registry.register_entry_point(s2)
 
         log = stream.getvalue()
         self.assertIn(
             "entry point 'Simple.js = dummy_builder:builder2' from package "
-            "'pkg 1.0' will generate an artifact at '%s' but it was already "
+            "'pkg 1.0' resolves to the path '%s' which was already "
             "registered to entry point 'Simple.js = dummy_builder:builder1'; "
             "conflicting entry point registration will be ignored." % st,
             log
@@ -319,7 +319,7 @@ class ArtifactRegistryTestCase(unittest.TestCase):
         log = stream.getvalue()
         self.assertIn(
             "entry point 'Case.js = dummy_builder:builder2' from package "
-            "'pkg 1.0' will generate an artifact at '%s' but it was already "
+            "'pkg 1.0' resolves to the path '%s' which was already "
             "registered to entry point 'case.js = dummy_builder:builder1'; "
             "conflicting entry point registration will be ignored." % ct,
             log

--- a/src/calmjs/tests/test_command.py
+++ b/src/calmjs/tests/test_command.py
@@ -84,7 +84,7 @@ class BuildArtifactCommandTestcase(unittest.TestCase):
         built_names = []
 
         class FakeBuilder(object):
-            def build_artifacts(self, name):
+            def process_package(self, name):
                 built_names.append(name)
 
         self.built_names = built_names

--- a/src/calmjs/tests/test_registry.py
+++ b/src/calmjs/tests/test_registry.py
@@ -36,9 +36,14 @@ class RegistryIntegrationTestCase(unittest.TestCase):
         ]})
         registry = calmjs.registry.Registry(
             'calmjs.registry', _working_set=working_set)
-        # This should not be registered or available
-        self.assertIsNone(registry.get_record('calmjs.module'))
-        self.assertIsNone(registry.get_record('failure'))
+
+        with pretty_logging(stream=mocks.StringIO()) as stream:
+            self.assertIsNone(registry.get_record('calmjs.module'))
+        self.assertIn("'calmjs.module' does not resolve", stream.getvalue())
+
+        with pretty_logging(stream=mocks.StringIO()) as stream:
+            self.assertIsNone(registry.get_record('failure'))
+        self.assertIn("ImportError 'failure", stream.getvalue())
 
     def test_registry_graceful_fail_bad_constructor(self):
         working_set = mocks.WorkingSet({'calmjs.registry': [

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -140,6 +140,15 @@ class BaseRuntimeTestCase(unittest.TestCase):
             bt.error(bt.argparser, None, 'error message')
         self.assertIn('error message', sys.stderr.getvalue())
 
+    def test_runtime_run_empty(self):
+        stub_stdouts(self)
+        working_set = mocks.WorkingSet({
+            'calmjs.runtime': [],
+        })
+        rt = runtime.Runtime(working_set=working_set, prog='dummy')
+        result = rt.run(rt.argparser, runtime='dummy')
+        self.assertIs(result, NotImplemented)
+
     def test_runtime_run_abort(self):
         class CustomRuntime(runtime.BaseRuntime):
             def run(self, export_target=None, **kwargs):
@@ -875,9 +884,10 @@ class RuntimeLoaderPluginRegistryOptionTestCase(unittest.TestCase):
             known.source_package_names, ['example.package'])
 
 
-class PackageManagerDriverTestCase(unittest.TestCase):
+class PackageManagerRuntimeTestCase(unittest.TestCase):
     """
-    Test cases for the package manager driver and argparse usage.
+    Test cases for the package manager driver/runtime and argparse
+    usage.
     """
 
     def test_command_creation(self):

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -890,6 +890,15 @@ class ArtifactRuntimeTestCase(unittest.TestCase):
     Test cases for the artifact runtime and subruntimes.
     """
 
+    def setUp(self):
+        from calmjs import artifact
+
+        def version(bin_path, version_flag='-v', kw={}):
+            return '0.0.0'
+
+        # provide a fake version to avoid implied execution
+        stub_item_attr_value(self, artifact, 'get_bin_version_str', version)
+
     def test_artifact_runtime_integration(self):
         stub_stdouts(self)
         working_set = mocks.WorkingSet({'calmjs.runtime': [


### PR DESCRIPTION
Refactor how the artifact registry is fit together, so that it can be teased apart.  Originally the goal was to move the generation functionality out of the registry class itself, but that turned into a reference implementation on how to stitch the new API together to generate the artifact.  The reasoning for retaining that extra functionality in the class is due to how it also handle the extra metadata file which should be centralised there.

Hopefully this is the last thing holding up the 3.0.0 release.