### PR TITLE
Artifact verification and sanity checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Changelog
   Node.js inject them internally (in ``module.paths``, current working
   directory has higher order of precedence over NODE_PATH), for the
   method ``BaseDriver.find_node_modules_basedir``.
+- Framework for predefined artifact generation for packages through the
+  ``calmjs.artifacts`` registry.
 - Also split off the directory resolution from the above method to
   ``BaseDriver.which_with_node_modules``.
 - Deprecated the existing toolchain.transpiler function as a standard

--- a/src/calmjs/artifact.py
+++ b/src/calmjs/artifact.py
@@ -141,6 +141,7 @@ from calmjs.toolchain import Toolchain
 from calmjs.toolchain import Spec
 from calmjs.toolchain import TOOLCHAIN_BIN_PATH
 from calmjs.toolchain import BEFORE_PREPARE
+from calmjs.toolchain import EXPORT_TARGET
 
 ARTIFACT_BASENAME = 'calmjs_artifacts'
 
@@ -512,7 +513,16 @@ class BaseArtifactRegistry(BaseRegistry):
                 logger.error(
                     "the builder referenced by the entry point '%s' "
                     "from package '%s' failed to produce a valid "
-                    "toolchain and spec",
+                    "toolchain",
+                    entry_point, entry_point.dist,
+                )
+                continue
+
+            if spec.get(EXPORT_TARGET) != export_target:
+                logger.error(
+                    "the builder referenced by the entry point '%s' "
+                    "from package '%s' failed to produce a spec with the "
+                    "expected export_path",
                     entry_point, entry_point.dist,
                 )
                 continue

--- a/src/calmjs/artifact.py
+++ b/src/calmjs/artifact.py
@@ -471,19 +471,25 @@ class BaseArtifactRegistry(BaseRegistry):
     def extract_builder_result(self, builder_result):
         return extract_builder_result(builder_result)
 
-    def iter_builders_for(self, package_name):
+    def iter_export_targets_for(self, package_name):
         for entry_point in self.iter_records_for(package_name):
+            export_target = self.records[
+                (entry_point.dist.project_name, entry_point.name)]
+
+            yield entry_point, export_target
+
+    def iter_builders_for(self, package_name):
+        for entry_point, export_target in self.iter_export_targets_for(
+                package_name):
             try:
                 builder = entry_point.resolve()
             except ImportError:
                 logger.error(
                     "unable to import the target builder for the entry point "
-                    "'%s' from package '%s'", entry_point, entry_point.dist,
+                    "'%s' from package '%s' to generate artifact '%s'",
+                    entry_point, entry_point.dist, export_target,
                 )
                 continue
-
-            export_target = self.records[
-                (entry_point.dist.project_name, entry_point.name)]
 
             if not self.verify_builder(builder):
                 logger.error(


### PR DESCRIPTION
This also fix a bug where unintended filesystem side-effect are performed in the iter_builders_for method of the ArtifactRegistry class.  Iteration through the created data types (for orchestrating execution) shouldn't cause states to mutate before the execution actually happens.