### PR TITLE
Dedicated class for artifact building

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+3.1.0 (Unreleased)
+------------------
+
+- Fix the modgen function in calmjs.indexer by actually not using the
+  marked as deprecated indexer functions by default, but instead use the
+  ``pkg_resources`` version as originally intended. [
+  `#30 <https://github.com/calmjs/calmjs/issues/30>`_
+  `#33 <https://github.com/calmjs/calmjs/issues/33>`_
+  ]
+- Ensure lookups on package names that have been normalized internally
+  by pkg_resources can still be resolved by their original name. [
+  `#31 <https://github.com/calmjs/calmjs/issues/31>`_
+  ]
+- Correctly return an unsuccessful exit code on various partial success
+  while running ``calmjs artifact build`` command and for the distutils
+  ``build_calmjs_artifacts`` command. [
+  `#27 <https://github.com/calmjs/calmjs/issues/27>`_
+  `#38 <https://github.com/calmjs/calmjs/issues/38>`_
+  ]
+
 3.0.0 (2018-01-10)
 ------------------
 


### PR DESCRIPTION
- Decouple the build function in the artifact runtime from the class
  into a separate standalone class that can be reused in the command
  class.
- Also fix up the build artifact command class such that it will also
  correctly abort when an artifact build failure occurs.  This also
  decouples the registry lookup from that class also and to allow the
  command classes to be composed as designed.
