### PR TITLE
Various fixes to the runtime/argparse interactions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ Changelog
   `#27 <https://github.com/calmjs/calmjs/issues/27>`_
   `#38 <https://github.com/calmjs/calmjs/issues/38>`_
   ]
+- Correctly locate the subparser(s) that were responsible for whatever
+  arguments they cannot recognize; includes cleaning up the interactions
+  between the runtime and argparser classes and Python 3.7 compatibility
+  fixes. [
+  `#41 <https://github.com/calmjs/calmjs/issues/41>`_
+  ]
 
 3.0.0 (2018-01-10)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -773,6 +773,15 @@ execution of scripts and binaries.
 Runtime reporting 'unrecognized arguments:' on declared arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+This issue should be fully resolved for calmjs>=3.1.0.
+
+The default behavior in the ArgumentParser defaults to uselessly blaming
+the root parser for any unrecognized arguments caused by its subparsers.
+The original workaround prior to calmjs-3.1.0 had the failure as
+documented below as its subparser resolver implementation was
+incomplete.  Either of these misleading behaviors impede the end users
+from being able to quickly locate the misplaced argument flags.
+
 For instance, if the |calmjs| command was executed like so resulting in
 error message may look like this:
 

--- a/src/calmjs/argparse.py
+++ b/src/calmjs/argparse.py
@@ -258,3 +258,16 @@ class ArgumentParser(argparse.ArgumentParser):
                 deprecation=deprecation,
             )
         return action
+
+    def soft_error(self, message):
+        """
+        Same as error, without the dying in a fire part.
+        """
+
+        self.print_usage(sys.stderr)
+        args = {'prog': self.prog, 'message': message}
+        self._print_message(
+            _('%(prog)s: error: %(message)s\n') % args, sys.stderr)
+
+    def unrecognized_arguments_error(self, args):
+        self.soft_error(_('unrecognized arguments: %s') % ' '.join(args))

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -526,6 +526,17 @@ class Runtime(BaseRuntime):
 
         commands = argparser.add_subparsers(
             dest=self.action_key, metavar='<command>')
+        # Python 3.7 has required set to True, which is correct in most
+        # cases but this disables the manual handling for cases where a
+        # command was not provided; also this generates a useless error
+        # message that simply states "<command> is required" and forces
+        # the program to exit.  As the goal of this suite of classes is
+        # to act as a helpful CLI front end, force required to be False
+        # to keep our manual handling and management of subcommands.
+        # Setting this as a property for compatibility with Python<3.7,
+        # as only in Python>=3.7 the add_subparsers can accept required
+        # as an argument.
+        commands.required = False
 
         for entry_point in self.iter_entry_points():
             inst = self.entry_point_load_validated(entry_point)

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -905,7 +905,8 @@ class ArtifactRuntimeTestCase(unittest.TestCase):
             'artifact = calmjs.runtime:artifact',
         ]})
         rt = runtime.Runtime(working_set=working_set)
-        rt(['artifact'])
+        # An underspecified command should also return False.
+        self.assertFalse(rt(['artifact']))
         # ensure the help for the command itself is printed
         self.assertIn(
             'helpers for the management of artifacts', sys.stdout.getvalue())
@@ -2361,7 +2362,7 @@ class MainIntegrationTestCase(unittest.TestCase):
         with self.assertRaises(SystemExit) as e:
             runtime.main([])
         self.assertIn('usage', sys.stdout.getvalue())
-        self.assertEqual(e.exception.args[0], 0)
+        self.assertEqual(e.exception.args[0], 1)
 
     def test_calmjs_main_console_entry_point_help(self):
         stub_stdouts(self)


### PR DESCRIPTION
Provide a comprehensive fix for the incorrect reporting of the responsible subparser when unrecognized arguments were provided, fully correcting the behavior as documented in relevant Troubleshooting subsection in the top-level documentation.  The fix will now report _all_ subparsers that unrecognized arguments.  For instance, previous behavior:

```
$ calmjs karma --build-dir=foo webpack package --cover-artifact
usage: calmjs karma [-h] [-d] [-q] [-v] [-V]
                    ...
                    [--cover-artifact] [--no-wrap-tests] [--cover-bundle] [-I]
                    <command> ...
calmjs karma: error: unrecognized arguments: --build-dir=foo --cover-artifact
```

Note how the the `--cover-artifact` flag was reported to be missing and that the help text show that it is one of supported flags - even though it's only for `calmjs karma`; the error was triggered inside `calmjs karma webpack` as where the flag was applied and rejected as unrecognised.  Now with this set of patches, the correct behavior is realised:

```
$ calmjs karma --build-dir=foo webpack package --cover-artifact
usage: calmjs karma [-h] [-d] [-q] [-v] [-V]
                    ...
                    [--cover-artifact] [--no-wrap-tests] [--cover-bundle] [-I]
                    <command> ...
calmjs karma: error: unrecognized arguments: --build-dir=foo
usage: calmjs karma webpack [-h] [--disable-calmjs-compat]
                            ...
                            [--build-dir <build_dir>]
                            ...
                            <package> [<package> ...]
calmjs karma webpack: error: unrecognized arguments: --cover-artifact
```

Also this also fixes some Python 3.7 compatibility issues.