### PR TITLE
Treat root level index.js entry point as fallback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ Changelog
     the default mapper will also accept the globber and the filename
     extension arguments.
 
+- For Node.js packages that didn't have a ``main`` or ``browser``
+  section defined in their ``package.json``, make use of the default
+  entry file ``index.js`` if it exists.  [
+  `#49 <https://github.com/calmjs/calmjs/issues/49>`_
+  ]
+
 3.2.1 (2018-05-16)
 ------------------
 

--- a/src/calmjs/npm.py
+++ b/src/calmjs/npm.py
@@ -68,17 +68,21 @@ def locate_package_entry_file(working_dir, package_name):
     with open(package_json) as fd:
         package_info = json.load(fd)
 
-    if not ('browser' in package_info or 'main' in package_info):
-        logger.debug(
-            "package.json for the npm package '%s' does not contain a main "
-            "entry point", package_name,
+    if ('browser' in package_info or 'main' in package_info):
+        # assume the target file exists because configuration files
+        # never lie /s
+        return join(
+            basedir,
+            *(package_info.get('browser') or package_info['main']).split('/')
         )
-        return
 
-    # assume the target file exists...
-    return join(
-        basedir,
-        *(package_info.get('browser') or package_info['main']).split('/')
+    index_js = join(basedir, 'index.js')
+    if exists(index_js):
+        return index_js
+
+    logger.debug(
+        "package.json for the npm package '%s' does not contain a main "
+        "entry point", package_name,
     )
 
 

--- a/src/calmjs/tests/test_npm.py
+++ b/src/calmjs/tests/test_npm.py
@@ -99,6 +99,24 @@ class LocatePackageTestCase(unittest.TestCase):
             )
         self.assertEqual("", stream.getvalue())
 
+    def test_plugin_package_success_implied_index_js(self):
+        working_dir = mkdtemp(self)
+        pkg_name = 'demo'
+        pkg_dir = join(working_dir, 'node_modules', pkg_name)
+        makedirs(pkg_dir)
+        with open(join(pkg_dir, 'package.json'), 'w') as fd:
+            fd.write('{}')
+
+        with open(join(pkg_dir, 'index.js'), 'w') as fd:
+            fd.write('(function () { return {} })();')
+
+        with pretty_logging(stream=StringIO(), level=DEBUG) as stream:
+            self.assertEqual(
+                join(pkg_dir, 'index.js'),
+                npm.locate_package_entry_file(working_dir, pkg_name),
+            )
+        self.assertEqual("", stream.getvalue())
+
 
 class NpmTestCase(unittest.TestCase):
 


### PR DESCRIPTION
- This is for Node.js packages that did not define one explicitly using
  the relevant field(s) in the package.json file.