### PR TITLE
Which should accept and return a path to a valid binary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+3.3.1 (2018-08-??)
+------------------
+
+- Correct the implementation of the helper function ``which`` such that
+  path arguments to valid executables are accepted and returned.  [
+  `#52 <https://github.com/calmjs/calmjs/issues/52>`_
+  ]
+
 3.3.0 (2018-07-23)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         'setuptools>=12',
         'calmjs.types',
-        'calmjs.parse>=1.0.0,<2',
+        'calmjs.parse>=1.0.0,!=1.1.0,!=1.1.1,<2',
     ],
     include_package_data=True,
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     keywords='',
     author='Tommy Yu',
     author_email='tommy.yu@auckland.ac.nz',
-    url='https://github.com/calmjs/',
+    url='https://github.com/calmjs/calmjs/',
     license='GPL',
     packages=find_packages('src', exclude=['ez_setup']),
     package_dir={'': 'src'},

--- a/src/calmjs/utils.py
+++ b/src/calmjs/utils.py
@@ -132,6 +132,10 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
     Loosely based on the version in python 3.3.
     """
 
+    if os.path.dirname(cmd):
+        if os.path.isfile(cmd) and os.access(cmd, mode):
+            return cmd
+
     if path is None:
         path = os.environ.get('PATH', defpath)
     if not path:


### PR DESCRIPTION
This previously was not necessary before but now that there are situations where its output is fed back in, and also to provide an implementation that more conforms to what is expected, this is now adjusted for that fact.

Of course, this entire mess should be removed once Python 2 support is dropped.