### PR TITLE
A few test cases still need to verify against case normalized paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   allow_failures:
     - os: osx
     - python: 3.8-dev
-    - env: TRAVIS_NODE_VERSION=7.4
+    - env: TRAVIS_NODE_VERSION=11
   include:
     - language: python
       python: 2.7
@@ -29,7 +29,7 @@ matrix:
             - yarn
     - language: python
       python: 3.5
-      env: TRAVIS_NODE_VERSION=8.11
+      env: TRAVIS_NODE_VERSION=8.14
       dist: trusty
       addons:
         apt:
@@ -40,7 +40,7 @@ matrix:
             - yarn
     - language: python
       python: 3.6
-      env: TRAVIS_NODE_VERSION=8.11
+      env: TRAVIS_NODE_VERSION=8.14
       dist: trusty
       addons:
         apt:
@@ -65,7 +65,7 @@ matrix:
       python: 3.8-dev
       sudo: true
       dist: xenial
-      env: TRAVIS_NODE_VERSION=10
+      env: TRAVIS_NODE_VERSION=11
       addons:
         apt:
           sources:
@@ -78,24 +78,24 @@ matrix:
       env: TRAVIS_NODE_VERSION=6.14
     - language: python
       python: pypy3
-      env: TRAVIS_NODE_VERSION=8.11
+      env: TRAVIS_NODE_VERSION=8.14
     # test different versions of Node.js on osx
     - language: node_js
       node_js: 4.9
       os: osx
-      env: TRAVIS_PYTHON_VERSION=3.4.5
+      env: TRAVIS_PYTHON_VERSION=3.4.9
     - language: node_js
       node_js: 6.14
       os: osx
       env: TRAVIS_PYTHON_VERSION=3.5.3
     - language: node_js
-      node_js: 8.11
+      node_js: 8.14
       os: osx
-      env: TRAVIS_PYTHON_VERSION=3.6.5
+      env: TRAVIS_PYTHON_VERSION=3.6.7
     - language: node_js
       node_js: 10
       os: osx
-      env: TRAVIS_PYTHON_VERSION=3.7.0
+      env: TRAVIS_PYTHON_VERSION=3.7.1
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -121,7 +121,7 @@ before_install:
 
 install:
   - pip install coverage flake8
-  - python setup.py develop
+  - pip install -e .
 script: 
   - flake8 setup.py src
   - coverage run --include=src/* -m unittest calmjs.tests.make_suite

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+3.3.2 (20??-??-??)
+------------------
+
+- Clean up a failing test case on Windows due to failure to use normcase
+  to normalize the path for comparison between test result and expected
+  answers.  [
+  `#53 <https://github.com/calmjs/calmjs/issues/53>`_
+  `#54 <https://github.com/calmjs/calmjs/issues/54>`_
+  ]
+
 3.3.1 (2018-08-20)
 ------------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,16 @@ environment:
     - PYTHON: "C:\\Python37"
       nodejs_version: "10"
 
+# adding an uppercase element in the path to test #54
+clone_folder: c:\projects\SomeLONGPath\calmjs
+
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - ps: Install-Product node $env:nodejs_version
-  - "%PYTHON%\\python.exe -m pip install coverage"
-  - "%PYTHON%\\python.exe setup.py install"
+  - "%PYTHON%\\python.exe -m pip install virtualenv"
+  - "%PYTHON%\\python.exe -m virtualenv Venv"
+  - "Venv\\Scripts\\activate"
+  - "pip install coverage ."
 
 test_script:
   # piping empty echo to disable the tty test which is reported as

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,8 @@ install:
   - "%PYTHON%\\python.exe -m pip install virtualenv"
   - "%PYTHON%\\python.exe -m virtualenv Venv"
   - "Venv\\Scripts\\activate"
-  - "pip install coverage ."
+  - "pip install coverage"
+  - "pip install -e ."
 
 test_script:
   # piping empty echo to disable the tty test which is reported as

--- a/src/calmjs/cli.py
+++ b/src/calmjs/cli.py
@@ -40,7 +40,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-version_expr = re.compile('((?:\d+)(?:\.\d+)*)')
+version_expr = re.compile(r'((?:\d+)(?:\.\d+)*)')
 
 
 def get_bin_version_str(bin_path, version_flag='-v', kw={}):


### PR DESCRIPTION
This is apparently still an issue when running the test case on Windows for older test cases that does not derive the path/testdata via packages like `pkg_resources`.

First reported by #53.