### PR TITLE
Registry for automatic application of advice packages to a target package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ Changelog
   enabled for all subclasses of Runtime.  [
   `#55 <https://github.com/calmjs/calmjs/issues/55>`_
   ]
+- Provide a registry for packages to specify which requirement (package)
+  to acquire toolchain advice from to apply by default for the relevant
+  toolchains.  This also necessitated some changes to where the optional
+  advices are applied, from the previous location applied as a setup
+  level advice applied by the standard toolchain runtime, to the default
+  sequence within the default toolchain itself.
 
 3.3.1 (2018-08-20)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,11 +20,16 @@ Changelog
   toolchains.  This also necessitated some changes to where the optional
   advices are applied, from the previous location applied as a setup
   level advice applied by the standard toolchain runtime, to the default
-  sequence within the default toolchain itself.
+  sequence within the default toolchain itself.  [
+  `#56 <https://github.com/calmjs/calmjs/issues/56>`_
+  ]
 
   - As a consequence of this feature, any setup advice that trigger a
     toolchain abort or cancel will not leave the cleanup advices not
     handled.
+  - This feature is implemented in a manner that allow manual invocation
+    of a toolchain with a list of manually provided advice_package be
+    able to always override the default specified ones.
 
 3.3.1 (2018-08-20)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Changelog
   level advice applied by the standard toolchain runtime, to the default
   sequence within the default toolchain itself.
 
+  - As a consequence of this feature, any setup advice that trigger a
+    toolchain abort or cancel will not leave the cleanup advices not
+    handled.
+
 3.3.1 (2018-08-20)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -755,6 +755,17 @@ are, however).  For a working example on how this may be achieved please
 refer to the implementations provided by |calmjs.rjs|_ or
 |calmjs.webpack|_.
 
+Toolchain Advice
+~~~~~~~~~~~~~~~~
+
+For package developers that need to provide additional instructions to
+a toolchain execution (e.g. for compatibility between RequireJS and also
+webpack for specific use case of features to a given package), the
+toolchain system will also make use of the advice system such that
+additional instructions may be created and registered for use and reuse
+by their dependents.  Much like the Toolchain, this feature is currently
+lacking in documentation outside of the test cases.
+
 Pre-defined artifact generation through |setuptools|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -101,11 +101,13 @@ setup(
             'calmjs.module = calmjs.module:ModuleRegistry',
             'calmjs.module.loader = calmjs.loaderplugin:ModuleLoaderRegistry',
             'calmjs.module.tests = calmjs.module:ModuleRegistry',
-            'calmjs.module.tests.loader'
-            ' = calmjs.loaderplugin:ModuleLoaderRegistry',
+            ('calmjs.module.tests.loader'
+                ' = calmjs.loaderplugin:ModuleLoaderRegistry'),
             'calmjs.py.module = calmjs.module:PythonicModuleRegistry',
             'calmjs.py.module.tests = calmjs.module:PythonicModuleRegistry',
             'calmjs.toolchain.advice = calmjs.toolchain:AdviceRegistry',
+            ('calmjs.toolchain.advice.apply'
+                ' = calmjs.toolchain:AdviceApplyRegistry'),
         ],
         'calmjs.reserved': [
             'calmjs.artifacts = calmjs',
@@ -124,6 +126,7 @@ setup(
             'calmjs.py.module = calmjs',
             'calmjs.py.module.tests = calmjs',
             'calmjs.toolchain.advice = calmjs',
+            'calmjs.toolchain.advice.apply = calmjs',
             'calmjs.webpack.loaderplugins = calmjs.webpack',
             'calmjs.webpack.static.loaderplugins = calmjs.webpack',
         ],

--- a/src/calmjs/indexer.py
+++ b/src/calmjs/indexer.py
@@ -100,14 +100,15 @@ def resource_filename_mod_entry_point(module_name, entry_point):
 
     if not result:
         logger.warning(
-            "resource path cannot be found for module '%s' and entry_point "
-            "'%s'", module_name, entry_point
+            "fail to resolve the resource path for module '%s' and "
+            "entry_point '%s'", module_name, entry_point
         )
         return None
     if not exists(result):
         logger.warning(
-            "resource path found at '%s' for module '%s' and entry_point "
-            "'%s', but it does not exist", result, module_name, entry_point,
+            "resource path resolved to be '%s' for module '%s' and "
+            "entry_point '%s', but it does not exist",
+            result, module_name, entry_point,
         )
         return None
     return result

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -912,7 +912,7 @@ class ToolchainRuntime(DriverRuntime):
         spec[ADVICE_PACKAGES] = kwargs.get(ADVICE_PACKAGES, [])
         if spec[ADVICE_PACKAGES]:
             logger.debug(
-                'preparing spec to apply optional advices from packages %r',
+                'sourcing optional advices from packages %r as specified',
                 spec[ADVICE_PACKAGES]
             )
 

--- a/src/calmjs/runtime.py
+++ b/src/calmjs/runtime.py
@@ -902,7 +902,7 @@ class ToolchainRuntime(DriverRuntime):
             default_key=1,
         )
         if not overwrite:
-            raise ToolchainCancel('cancelation initiated by user')
+            raise ToolchainCancel('cancellation initiated by user')
 
     def prepare_spec_debug_flag(self, spec, **kwargs):
         spec[DEBUG] = self.debug

--- a/src/calmjs/testing/spec.py
+++ b/src/calmjs/testing/spec.py
@@ -29,3 +29,24 @@ def advice_order(spec, extras):
             raise toolchain.ToolchainAbort()  # pragma: no cover
 
     spec.advise(toolchain.CLEANUP, verify_build_dir)
+
+
+def advice_marker(spec, extras):
+    # this documents the behavior if the implementation of a toolchain
+    # advice that was registered had acted immediately on the spec
+    from calmjs import toolchain
+
+    spec.setdefault('marker_too_soon', [])
+    spec['marker_too_soon'].append(
+        (list(spec.get('advice_packages', [])), extras)
+    )
+
+    # to properly manage the process, it should register a function as
+    # an advice.
+    def advice():
+        spec.setdefault('marker_delayed', [])
+        spec['marker_delayed'].append(
+            (list(spec.get('advice_packages', [])), extras)
+        )
+
+    spec.advise(toolchain.SETUP, advice)

--- a/src/calmjs/testing/spec.py
+++ b/src/calmjs/testing/spec.py
@@ -31,22 +31,24 @@ def advice_order(spec, extras):
     spec.advise(toolchain.CLEANUP, verify_build_dir)
 
 
+def str_list(items):
+    return [str(item) for item in items]
+
+
 def advice_marker(spec, extras):
     # this documents the behavior if the implementation of a toolchain
     # advice that was registered had acted immediately on the spec
     from calmjs import toolchain
 
     spec.setdefault('marker_too_soon', [])
-    spec['marker_too_soon'].append(
-        (list(spec.get('advice_packages', [])), extras)
-    )
+    spec['marker_too_soon'].append((str_list(
+        spec.get('advice_packages_applied_requirements', [])), extras))
 
     # to properly manage the process, it should register a function as
     # an advice.
     def advice():
         spec.setdefault('marker_delayed', [])
-        spec['marker_delayed'].append(
-            (list(spec.get('advice_packages', [])), extras)
-        )
+        spec['marker_delayed'].append((str_list(
+            spec.get('advice_packages_applied_requirements', [])), extras))
 
-    spec.advise(toolchain.SETUP, advice)
+    spec.advise(toolchain.BEFORE_PREPARE, advice)

--- a/src/calmjs/tests/test_indexer.py
+++ b/src/calmjs/tests/test_indexer.py
@@ -276,8 +276,8 @@ class IndexerTestCase(unittest.TestCase):
         self.assertIn(
             "module 'nothing' and entry_point 'demo = demo'", err)
         # the input is fetched using a working entry_point, after all
-        self.assertIn("path found at '" + calmjs_dist_dir, err)
-        self.assertIn("it does not exist", fd.getvalue())
+        self.assertIn("resource path resolved to be '" + calmjs_dist_dir, err)
+        self.assertIn("but it does not exist", fd.getvalue())
 
     def test_get_modpath_pkg_resources_invalid(self):
         # fake both module and entry point, which will trigger an import
@@ -298,7 +298,7 @@ class IndexerTestCase(unittest.TestCase):
         with pretty_logging(stream=StringIO()) as fd:
             self.assertEqual([], indexer.modpath_pkg_resources(nothing, ep))
         self.assertIn(
-            "resource path cannot be found for module 'nothing' and "
+            "fail to resolve the resource path for module 'nothing' and "
             "entry_point 'nothing = nothing'", fd.getvalue())
 
     def test_module1_loader_es6(self):

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -778,9 +778,13 @@ class ToolchainRuntimeTestCase(unittest.TestCase):
 
         self.assertEqual(result['dummy'], ['dummy', 'bad'])
         err = sys.stderr.getvalue()
+        err_lines = err.splitlines()
 
-        self.assertIn('prepare spec with optional advices from packages', err)
-        self.assertIn('example.package', err)
+        self.assertIn('sourcing optional advices from ', err_lines[0])
+        self.assertIn('example.package', err_lines[0])
+        self.assertIn('as specified', err_lines[0])
+        self.assertIn(
+            "applying toolchain advice for package 'example.package'", err)
         self.assertIn('failure encountered while setting up advices', err)
 
         # Doing it normally should not result in that optional key.
@@ -864,6 +868,10 @@ class ToolchainRuntimeTestCase(unittest.TestCase):
         packages should NOT be added immediately, as it is executed
         before a number of very important advices were added by the
         toolchain itself.
+
+        However, given that the functionality has been moved from the
+        runtime to the toolchain itself, this should be less of an issue
+        but this test will remain as a check against regression of sort.
         """
 
         from calmjs.registry import _inst as root_registry

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -108,6 +108,13 @@ class BaseRuntimeTestCase(unittest.TestCase):
         self.assertEqual(runtime.norm_args([]), [])
         self.assertEqual(runtime.norm_args(['arg']), ['arg'])
 
+    def test_base_runtime_unknown_args(self):
+        stub_stdouts(self)
+        bt = runtime.BaseRuntime()
+        with self.assertRaises(SystemExit):
+            bt(['unknown'])
+        self.assertIn('unrecognized arguments: unknown', sys.stderr.getvalue())
+
     def test_global_flags(self):
         def fake_parse(args):
             warnings.warn('fake deprecation', DeprecationWarning)

--- a/src/calmjs/tests/test_runtime.py
+++ b/src/calmjs/tests/test_runtime.py
@@ -799,6 +799,104 @@ class ToolchainRuntimeTestCase(unittest.TestCase):
             result = rt(['--export-target', 'dummy'])
         self.assertNotIn('dummy', result)
 
+    def test_spec_toolchain_advice_apply(self):
+        # This mostly just run through the toolchain to ensure that the
+        # advice is applied without any arguments.
+        from calmjs.registry import _inst as root_registry
+        key_t_a = toolchain.CALMJS_TOOLCHAIN_ADVICE
+        key_t_a_a = toolchain.CALMJS_TOOLCHAIN_ADVICE_APPLY
+        stub_stdouts(self)
+
+        self.addCleanup(root_registry.records.pop, key_t_a, None)
+        self.addCleanup(root_registry.records.pop, key_t_a_a, None)
+
+        make_dummy_dist(self, ((
+            'entry_points.txt',
+            '[calmjs.toolchain.advice]\n'
+            'calmjs.toolchain:NullToolchain'
+            ' = calmjs.testing.spec:advice_marker\n'
+            '\n'
+            '[calmjs.toolchain.advice.apply]\n'
+            'example.package = example.package\n'
+        ),), 'example.package', '1.0')
+
+        make_dummy_dist(self, ((
+            'entry_points.txt',
+            '[calmjs.toolchain.advice.apply]\n'
+            'example.package = example.package[argument]\n'
+        ),), 'example.other_package', '1.0')
+
+        make_dummy_dist(self, (
+            ('requires.txt', '\n'.join([
+                'example.package',
+                'example.other_package',
+            ])),
+            ('entry_points.txt', '',),
+        ), 'dependent', '1.0')
+
+        working_set = pkg_resources.WorkingSet([self._calmjs_testing_tmpdir])
+
+        root_registry.records[key_t_a] = toolchain.AdviceRegistry(
+            key_t_a, _working_set=working_set)
+        root_registry.records[key_t_a_a] = toolchain.AdviceApplyRegistry(
+            key_t_a_a, _working_set=working_set)
+
+        tc = toolchain.NullToolchain()
+        rt = runtime.SourcePackageToolchainRuntime(tc)
+
+        result = rt([
+            '--export-target', join(self.cwd, 'dummy_export'),
+            'example.package', '-v',
+        ])
+
+        self.assertEqual([([], [])], result['marker_too_soon'])
+        self.assertEqual([(['example.package'], [])], result['marker_delayed'])
+        err = sys.stderr.getvalue()
+        err_lines = err.splitlines()
+
+        self.assertIn(
+            "source package 'example.package' specified advice packages",
+            err_lines[0])
+        self.assertIn('example.package', err_lines[0])
+        self.assertIn('to be applied', err_lines[0])
+
+        # Doing it normally should not result in that optional key.
+        with pretty_logging(logger='calmjs', stream=mocks.StringIO()) as s:
+            result = rt([
+                '--export-target', join(self.cwd, 'dummy_export'),
+                'example.other_package', '-v',
+            ])
+
+        # arguments will be passed, but the advice_packages key won't be
+        # assigned.
+        self.assertEqual([([], ['argument'])], result['marker_too_soon'])
+        # naturally, it would be available in the setup.
+        self.assertEqual(
+            [(['example.package[argument]'], ['argument'])],
+            result['marker_delayed']
+        )
+
+        err_lines = s.getvalue().splitlines()
+        self.assertIn(
+            "source package 'example.other_package' specified advice packages",
+            err_lines[0])
+        self.assertIn('example.package[argument]', err_lines[0])
+        self.assertIn('to be applied', err_lines[0])
+
+        # This tests the dependent case where the dependent package
+        # declares both as dependents, but it doesn't declare the
+        # records for the relevant registries.
+        with pretty_logging(logger='calmjs', stream=mocks.StringIO()) as s:
+            result = rt([
+                '--export-target', join(self.cwd, 'dummy_export'),
+                'dependent', '-v',
+            ])
+
+        # shouldn't have anything.
+        self.assertNotIn('marker_too_soon', result)
+        self.assertNotIn('marker_delayed', result)
+        self.assertEqual('', s.getvalue())
+
     def test_spec_advise_debugger(self):
         # this is meant for advanced usage, thus undocumented.
         from calmjs import utils

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -45,6 +45,7 @@ from calmjs.toolchain import spec_update_loaderplugin_registry
 from calmjs.toolchain import toolchain_spec_compile_entries
 from calmjs.toolchain import toolchain_spec_prepare_loaderplugins
 
+from calmjs.toolchain import SETUP
 from calmjs.toolchain import CLEANUP
 from calmjs.toolchain import SUCCESS
 from calmjs.toolchain import AFTER_FINALIZE
@@ -1345,6 +1346,18 @@ class ToolchainTestCase(unittest.TestCase):
         self.assertTrue(exists(join(build_dir, target2)))
         self.assertTrue(exists(join(build_dir, target3)))
         self.assertTrue(exists(join(build_dir, target4)))
+
+    def test_toolchain_setup_advice_abort_does_cleanup(self):
+        spec = Spec()
+
+        def abort(*a, **kw):
+            raise ToolchainAbort()
+
+        spec.advise(SETUP, abort)
+        with pretty_logging(stream=StringIO()):
+            with self.assertRaises(ToolchainAbort):
+                self.toolchain(spec)
+        self.assertFalse(exists(spec.get('build_dir')))
 
 
 class MockLPHandler(BaseLoaderPluginHandler):

--- a/src/calmjs/tests/test_toolchain.py
+++ b/src/calmjs/tests/test_toolchain.py
@@ -29,7 +29,7 @@ from calmjs.loaderplugin import BaseLoaderPluginRegistry
 from calmjs.loaderplugin import BaseLoaderPluginHandler
 
 from calmjs.toolchain import CALMJS_TOOLCHAIN_ADVICE
-from calmjs.toolchain import CALMJS_TOOLCHAIN_ADVICE_APPLY
+from calmjs.toolchain import CALMJS_TOOLCHAIN_ADVICE_APPLY_SUFFIX
 from calmjs.toolchain import AdviceRegistry
 from calmjs.toolchain import AdviceApplyRegistry
 from calmjs.toolchain import Spec
@@ -736,7 +736,8 @@ class AdviceRegistryTestCase(unittest.TestCase):
             self.assertIsNone(
                 reg.process_toolchain_spec_package(object(), Spec(), 'calmjs'))
         self.assertIn(
-            "must call process_toolchain_spec_package with a toolchain",
+            "apply_toolchain_spec or process_toolchain_spec_package must be "
+            "invoked with a toolchain instance, not <object",
             s.getvalue(),
         )
 
@@ -767,10 +768,11 @@ class AdviceRegistryTestCase(unittest.TestCase):
             reg.process_toolchain_spec_package(
                 toolchain, spec, 'example.package')
 
-        self.assertEqual(spec, {'dummy': ['dummy']})
+        self.assertEqual(spec['dummy'], ['dummy'])
         self.assertIn(
             "found advice setup steps registered for package/requirement "
-            "'example.package' for toolchain 'calmjs.toolchain:Toolchain'",
+            "'example.package'; checking for compatibility with toolchain "
+            "'calmjs.toolchain:Toolchain'",
             s.getvalue(),
         )
 
@@ -815,8 +817,8 @@ class AdviceRegistryTestCase(unittest.TestCase):
         # inheritance applies.
         self.assertIn(
             "found advice setup steps registered for package/requirement "
-            "'example.package' for toolchain 'calmjs.toolchain:NullToolchain'",
-            err,
+            "'example.package'; checking for compatibility with toolchain "
+            "'calmjs.toolchain:NullToolchain'", err,
         )
         self.assertIn("ERROR", err)
         self.assertIn(
@@ -824,7 +826,9 @@ class AdviceRegistryTestCase(unittest.TestCase):
             err)
 
         # partial execution will be done, so do test stuff.
-        self.assertEqual(spec, {'dummy': ['dummy', 'bad']})
+        self.assertEqual(spec['dummy'], ['dummy', 'bad'])
+        self.assertEqual(spec['advice_packages_applied_requirements'], [
+            pkg_resources.Requirement.parse('example.package')])
 
     def test_standard_toolchain_advice_extras(self):
         make_dummy_dist(self, ((
@@ -844,8 +848,17 @@ class AdviceRegistryTestCase(unittest.TestCase):
         self.assertEqual(spec['extras'], ['a', 'bc', 'd'])
         self.assertIn(
             "found advice setup steps registered for package/requirement "
-            "'example.package[a,bc,d]' for toolchain ", s.getvalue()
+            "'example.package[a,bc,d]'", s.getvalue()
         )
+        self.assertIn(
+            "entry_point 'calmjs.toolchain:NullToolchain = "
+            "calmjs.tests.test_toolchain:dummy' registered by advice package "
+            "'example.package[a,bc,d]' applied as an advice setup step by "
+            "calmjs.toolchain:AdviceRegistry 'calmjs.toolchain.advice'",
+            s.getvalue()
+        )
+        self.assertEqual(spec['advice_packages_applied_requirements'], [
+            pkg_resources.Requirement.parse('example.package[a,bc,d]')])
 
     def test_standard_toolchain_advice_malformed(self):
         reg = AdviceRegistry(CALMJS_TOOLCHAIN_ADVICE)
@@ -857,10 +870,237 @@ class AdviceRegistryTestCase(unittest.TestCase):
             "the specified value 'calmjs:thing' for advice setup is not valid",
             s.getvalue(),
         )
+        self.assertNotIn('advice_packages_applied_requirements', spec)
+
+        spec = Spec()
+        spec['advice_packages'] = ['calmjs:thing']
+        with pretty_logging(stream=StringIO()) as s:
+            reg.apply_toolchain_spec(toolchain, spec)
+        self.assertIn(
+            "the specified value 'calmjs:thing' for advice setup is not valid",
+            s.getvalue(),
+        )
+        self.assertNotIn('advice_packages_applied_requirements', spec)
+
+    def test_apply_toolchain_spec_apply_incompatible_toolchain(self):
+        make_dummy_dist(self, ((
+            'entry_points.txt',
+            '[demo.registry]\n'
+            'calmjs.toolchain:NullToolchain = '
+            'calmjs.tests.test_toolchain:dummy\n'
+        ),), 'example.package', '1.0')
+
+        working_set = pkg_resources.WorkingSet([self._calmjs_testing_tmpdir])
+        reg = AdviceRegistry('demo.registry', _working_set=working_set)
+        # Step registered for NullToolchain
+        toolchain = Toolchain()
+        spec = Spec()
+        spec['advice_packages'] = ['example.package']
+
+        with pretty_logging(stream=StringIO()) as s:
+            reg.apply_toolchain_spec(toolchain, spec)
+
+        self.assertIn(
+            "'example.package'; checking for compatibility with toolchain "
+            "'calmjs.toolchain:Toolchain'", s.getvalue(),
+        )
+        self.assertIn("no compatible advice setup steps found", s.getvalue())
+        # also verify the warning log entry when missing .apply registry
+        self.assertIn(
+            "registry key 'demo.registry.apply' resulted in None which is not "
+            "a valid advice apply registry; no package level advice apply "
+            "steps will be applied", s.getvalue()
+        )
+
+    def test_apply_toolchain_spec_multiple_specified(self):
+        make_dummy_dist(self, ((
+            'entry_points.txt',
+            '[calmjs.toolchain.advice]\n'
+            'calmjs.toolchain:NullToolchain = '
+            'calmjs.tests.test_toolchain:dummy\n'
+        ),), 'example.package', '1.0')
+
+        working_set = pkg_resources.WorkingSet([self._calmjs_testing_tmpdir])
+        reg = AdviceRegistry(CALMJS_TOOLCHAIN_ADVICE, _working_set=working_set)
+        toolchain = NullToolchain()
+        spec = Spec()
+        spec['advice_packages'] = [
+            'example.package[foo]', 'example.package[bar]']
+
+        with pretty_logging(stream=StringIO()) as s:
+            reg.apply_toolchain_spec(toolchain, spec)
+
+        self.assertIn(
+            "entry_point 'calmjs.toolchain:NullToolchain = "
+            "calmjs.tests.test_toolchain:dummy' registered by advice package "
+            "'example.package[foo]' applied as an advice setup step by "
+            "calmjs.toolchain:AdviceRegistry 'calmjs.toolchain.advice'",
+            s.getvalue(),
+        )
+        self.assertIn(
+            "entry_point 'calmjs.toolchain:NullToolchain = "
+            "calmjs.tests.test_toolchain:dummy' registered by advice package "
+            "'example.package[bar]' applied as an advice setup step by "
+            "calmjs.toolchain:AdviceRegistry 'calmjs.toolchain.advice'",
+            s.getvalue(),
+        )
+        self.assertIn(
+            "advice package 'example.package[bar]' was previously applied as "
+            "'example.package[foo]'; the recommended usage manner is to only "
+            "specify any given advice package once complete with all the "
+            "required extras, and that underlying implementation be "
+            "structured in a manner that support this one-shot invocation "
+            "format", s.getvalue(),
+        )
+        self.assertEqual(spec['advice_packages_applied_requirements'], [
+            pkg_resources.Requirement.parse('example.package[foo]'),
+            pkg_resources.Requirement.parse('example.package[bar]'),
+        ])
+
+        # applying again, will trigger the warning showing that was blocked
+        with pretty_logging(stream=StringIO(), level=logging.WARNING) as s:
+            reg.apply_toolchain_spec(toolchain, spec)
+
+        self.assertIn(
+            "advice package 'example.package[foo]' already applied as "
+            "'example.package[bar]'; skipping", s.getvalue(),
+        )
+        self.assertIn(
+            "advice package 'example.package[bar]' already applied as "
+            "'example.package[bar]'; skipping", s.getvalue(),
+        )
+        # show that no additional application was done.
+        self.assertEqual(2, len(spec['advice_packages_applied_requirements']))
+        # manual step will still increase it
+        with pretty_logging(stream=StringIO()):
+            reg.process_toolchain_spec_package(
+                toolchain, spec, 'example.package[bar]')
+        self.assertEqual(3, len(spec['advice_packages_applied_requirements']))
+
+    def test_apply_spec_toolchain_not_installed(self):
+        reg = AdviceRegistry('demo.advice', _working_set=WorkingSet({}))
+        toolchain = NullToolchain()
+        spec = Spec()
+
+        with pretty_logging(stream=StringIO()) as s:
+            reg.process_toolchain_spec_package(toolchain, spec, 'example')
+
+        self.assertIn(
+            "advice setup steps required from package/requirement 'example', "
+            "however it is not found or not installed in this environment",
+            s.getvalue()
+        )
+
+    def test_apply_spec_toolchain_override_apply(self):
+        from calmjs.registry import _inst as root_registry
+
+        self.addCleanup(root_registry.records.pop, 'demo.advice', None)
+        self.addCleanup(root_registry.records.pop, 'demo.advice.apply', None)
+
+        make_dummy_dist(self, ((
+            'entry_points.txt',
+            '[demo.advice]\n'
+            'calmjs.toolchain:NullToolchain'
+            ' = calmjs.testing.spec:advice_marker\n'
+            '\n'
+            '[demo.advice.apply]\n'
+            'example.package = example.package[main]\n'
+        ),), 'example.package', '1.0')
+
+        make_dummy_dist(self, ((
+            'entry_points.txt',
+            '[demo.advice.apply]\n'
+            'example.package = example.package[other]\n'
+        ),), 'example.other_package', '1.0')
+
+        working_set = pkg_resources.WorkingSet([self._calmjs_testing_tmpdir])
+
+        reg = root_registry.records['demo.advice'] = AdviceRegistry(
+            'demo.advice', _working_set=working_set)
+        root_registry.records['demo.advice.apply'] = AdviceApplyRegistry(
+            'demo.advice.apply', _working_set=working_set)
+
+        toolchain = NullToolchain()
+        spec = Spec(
+            advice_packages=['example.package[manual]'],
+            source_package_names=['example.package', 'example.other_package'],
+        )
+
+        with pretty_logging(stream=StringIO()) as s:
+            reg.apply_toolchain_spec(toolchain, spec)
+
+        self.assertIn(
+            "invoking apply_toolchain_spec using instance of "
+            "calmjs.toolchain:AdviceRegistry named 'demo.advice'",
+            s.getvalue(),
+        )
+        self.assertIn(
+            "skipping specified advice package 'example.package[main]' as "
+            "'example.package[manual]' was already applied", s.getvalue(),
+        )
+        self.assertIn(
+            "skipping specified advice package 'example.package[other]' as "
+            "'example.package[manual]' was already applied", s.getvalue(),
+        )
+        self.assertEqual(spec['advice_packages_applied_requirements'], [
+            pkg_resources.Requirement.parse('example.package[manual]'),
+        ])
 
     def test_toolchain_advice_integration(self):
+        make_dummy_dist(self, ((
+            'entry_points.txt',
+            '[demo.advice]\n'
+            'calmjs.toolchain:NullToolchain'
+            ' = calmjs.testing.spec:advice_marker\n'
+            '\n'
+            '[demo.advice.apply]\n'
+            'example.package = example.package[main]\n'
+        ),), 'example.package', '1.0')
+
+        working_set = pkg_resources.WorkingSet([self._calmjs_testing_tmpdir])
+
+        stub_item_attr_value(self, calmjs_toolchain, 'get_registry', {
+            'demo.advice': AdviceRegistry(
+                'demo.advice', _working_set=working_set),
+            'demo.advice.apply': AdviceApplyRegistry(
+                'demo.advice.apply', _working_set=working_set),
+        }.get)
+
+        toolchain = NullToolchain()
+        spec = Spec(source_package_names=['example.package'])
+        with pretty_logging(stream=StringIO()) as s:
+            toolchain.setup_apply_advice_packages(spec)
+
+        self.assertIn(
+            "registry key 'calmjs.toolchain.advice' resulted in None which is "
+            "not a valid advice registry; all package advice steps will be "
+            "skipped",
+            s.getvalue(),
+        )
+        self.assertNotIn('advice_packages_applied_requirements', spec)
+
+        spec = Spec(
+            source_package_names=['example.package'],
+            calmjs_toolchain_advice_registry='demo.advice',
+        )
+        with pretty_logging(stream=StringIO()) as s:
+            toolchain.setup_apply_advice_packages(spec)
+
+        self.assertIn(
+            "setting up advices using calmjs.toolchain:AdviceRegistry "
+            "'demo.advice'",
+            s.getvalue(),
+        )
+        self.assertNotIn(spec['advice_packages_applied_requirements'], [
+            pkg_resources.Requirement.parse('example.package[main]'),
+        ])
+
+    def test_toolchain_advice_registry_registration(self):
         reg = get(CALMJS_TOOLCHAIN_ADVICE)
         self.assertTrue(isinstance(reg, AdviceRegistry))
+        reg = get(
+            CALMJS_TOOLCHAIN_ADVICE + CALMJS_TOOLCHAIN_ADVICE_APPLY_SUFFIX)
+        self.assertTrue(isinstance(reg, AdviceApplyRegistry))
 
 
 class AdviceApplyRegistryTestCase(unittest.TestCase):
@@ -874,11 +1114,16 @@ class AdviceApplyRegistryTestCase(unittest.TestCase):
 
         working_set = pkg_resources.WorkingSet([self._calmjs_testing_tmpdir])
         reg = AdviceApplyRegistry(
-            CALMJS_TOOLCHAIN_ADVICE_APPLY, _working_set=working_set)
+            CALMJS_TOOLCHAIN_ADVICE + CALMJS_TOOLCHAIN_ADVICE_APPLY_SUFFIX,
+            _working_set=working_set
+        )
         # key will be normalized
         record = reg.get_record('example-namespace-package')
         self.assertEqual(1, len(record))
-        self.assertEqual('example.advice[extra]', record[0])
+        self.assertEqual(
+            pkg_resources.Requirement.parse('example.advice[extra]'),
+            record[0],
+        )
 
     def test_manual_registration(self):
         reg = AdviceApplyRegistry('demo', _working_set=WorkingSet({}))
@@ -889,7 +1134,8 @@ class AdviceApplyRegistryTestCase(unittest.TestCase):
             reg._init_entry_point(entry_point)
         record = reg.get_record('package')
         self.assertEqual(1, len(record))
-        self.assertEqual('value[extra]', record[0])
+        self.assertEqual(
+            pkg_resources.Requirement.parse('value[extra]'), record[0])
         self.assertEqual(s.getvalue(), '')
 
     def test_manual_incomplete_entry_point(self):

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -770,7 +770,7 @@ class Spec(dict):
 
         while advices:
             try:
-                # cleanup basically done lifo (last in first out)
+                # advice processing is done lifo (last in first out)
                 values = advices.pop()
                 advice, a, kw = values
                 if not ((callable(advice)) and
@@ -1701,13 +1701,13 @@ class Toolchain(BaseDriver):
         # ensure advices specific to packages are applied
         self.setup_apply_advice_packages(spec)
 
-        # Finally, handle setup which may set up the deferred advices,
-        # as all the toolchain (and its runtime and/or its parent
-        # runtime and related toolchains) spec advises should have been
-        # done.
-        spec.handle(SETUP)
-
         try:
+            # Finally, handle setup which may set up the deferred
+            # advices, as all the toolchain (and its runtime and/or its
+            # parent runtime and related toolchains) spec advises should
+            # have been done.
+            spec.handle(SETUP)
+
             process = ('prepare', 'compile', 'assemble', 'link', 'finalize')
             for p in process:
                 spec.handle('before_' + p)

--- a/src/calmjs/toolchain.py
+++ b/src/calmjs/toolchain.py
@@ -1559,11 +1559,9 @@ class Toolchain(BaseDriver):
         advice_packages = spec.get(ADVICE_PACKAGES) or []
         if isinstance(advice_packages, (list, tuple)) and advice_packages:
             advice_registry = get_registry(CALMJS_TOOLCHAIN_ADVICE)
-            logger.debug(
-                'prepare spec with optional advices from packages %r',
-                advice_packages
-            )
             for pkg_name in advice_packages:
+                logger.debug(
+                    "applying toolchain advice for package '%s'" % pkg_name)
                 advice_registry.process_toolchain_spec_package(
                     self, spec, pkg_name)
 


### PR DESCRIPTION
This change provides a registry where packages may specify what advice package provide additional hints for the toolchain as advices that will be applied to a spec during a build process.